### PR TITLE
docs: Update Firefox development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,16 @@ This architecture ensures that your content remains exclusively on your device t
    ```
    git clone git@github.com:jatinkrmalik/LLMFeeder.git
    ```
-
-2. Follow the browser-specific instructions from Option 2 above to load the extension.
+   (If you've already cloned, ensure you are on the desired branch/commit.)
+2. Navigate to the cloned directory:
+   ```
+   cd LLMFeeder
+   ```
+3. Open Chrome and navigate to `chrome://extensions/`
+4. Enable "Developer mode" by toggling the switch in the top right
+5. Click "Load unpacked" and select the `extension` directory within the cloned repository.
+6. The LLMFeeder extension should now appear in your extensions list.
+7. Click the puzzle piece icon in Chrome toolbar and pin LLMFeeder for easy access.
 
 #### For Firefox
 
@@ -95,10 +103,20 @@ This architecture ensures that your content remains exclusively on your device t
    ```
    git clone git@github.com:jatinkrmalik/LLMFeeder.git
    ```
-2. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`
-3. Click "Load Temporary Add-on..."
-4. Select the `manifest.json` file inside the `extension` directory.
-5. The extension will appear in your Firefox extensions list for the current session.
+   (If you've already cloned, ensure you are on the desired branch/commit.)
+2. Navigate to the cloned directory:
+   ```
+   cd LLMFeeder
+   ```
+3. Run the build script to prepare the Firefox-specific files:
+   ```bash
+   ./scripts/build.sh firefox
+   ```
+   This will create a temporary build directory `.tmp-build/firefox` with the correct manifest and files.
+4. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`
+5. Click "Load Temporary Add-on..."
+6. Select the `manifest.json` file located inside the `.tmp-build/firefox` directory (NOT the one in the `extension` directory).
+7. The LLMFeeder extension should now appear in your Firefox extensions list for the current session.
 
 ### Usage
 


### PR DESCRIPTION
Fixes #30 

---

## Changes Made
This PR addresses user-reported issues regarding the development setup for Firefox. The previous instructions in `README.md` were causing errors because they pointed to a Chrome-specific manifest file.

The changes made include:
-   Updated the Firefox "From Source (Development)" instructions to include running the build script (`./scripts/build.sh firefox`) before loading the extension.
-   Clarified that developers must load the temporary add-on from the generated `.tmp-build/firefox` directory, which contains the correct Firefox-compatible manifest.
-   This resolves the `background service_worker is currently disabled` error when setting up the extension on Firefox for development.
-   Added minor clarifications to the Chrome development instructions for better consistency.

## Test URLs
N/A. This is a documentation-only change and does not affect the extension's runtime behavior. The new instructions have been verified to work for a local Firefox development setup.

## Screenshot
N/A. The changes are purely textual in the `README.md` file.