### PR TITLE
Toggle between dark and light mode in extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 </div>
 
-A browser extension that converts web page content to clean Markdown format and copies it to clipboard with a single click, perfect for feeding content to Large Language Models (LLMs). Available for both Chrome and Firefox.
+A browser extension that converts web page content to clean Markdown format and copies it to clipboard with a single click, perfect for feeding content to Large Language Models (LLMs). Available for both [Chrome](https://chromewebstore.google.com/detail/llmfeeder-webpage-to-mark/cjjfhhapabcpcokkfldbiiojiphbifdk) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/llmfeeder/).
 
 ## Demo
 

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,8 +15,8 @@
     <div class="container">
       <header class="header">
         <h1>LLMFeeder</h1>
-        <div class="theme-container">
-          <div class="dark-icon">
+        <button class="theme-container">
+          <div class="toggle-dark">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -32,7 +32,7 @@
               />
             </svg>
           </div>
-          <div class="light-icon hidden">
+          <div class="toggle-light hidden">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -48,7 +48,7 @@
               />
             </svg>
           </div>
-        </div>
+        </button>
         <p class="tagline">
           Convert web pages to clean Markdown and copy to clipboard so you can
           feed it to your favorite LLM model as context.

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,105 +1,163 @@
 <!DOCTYPE html>
 <html lang="en">
-<!-- Created by @jatinkrmalik (https://github.com/jatinkrmalik) -->
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LLMFeeder</title>
-  <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap">
-</head>
-<body>
-  <div class="container">
-    <header class="header">
-      <h1>LLMFeeder</h1>
-      <p class="tagline">Convert web pages to clean Markdown and copy to clipboard so you can feed it to your favorite LLM model as context.</p>
-    </header>
-    
-    <div class="main-controls">
-      <button id="convertBtn" class="primary-btn">
-        <span class="btn-text">Convert & Copy</span>
-        <span id="convertShortcut" class="shortcut-badge"></span>
-      </button>
-      <div id="statusIndicator" class="status">Ready</div>
-    </div>
-    
-    <div id="previewContainer" class="preview-container hidden">
-      <h2>Preview</h2>
-      <div id="previewContent" class="preview-content"></div>
-    </div>
-
-    <div id="downloadMarkdownFileContainer" class="download-markdown-file-container hidden">
-      <button id="downloadMarkdownFileBtn" class="primary-btn">
-        <span class="btn-text">Download As Markdown File</span>
-      </button>
-
-      <div id="downloadStatusIndicator" class="status"></div>
-    </div>
-    
-    <div class="settings-section">
-      <button id="settingsToggleBtn" class="settings-toggle-btn">
-        <span class="btn-text">Settings</span>
-        <span class="toggle-icon">▼</span>
-      </button>
-      
-      <div id="settingsContainer" class="settings-container hidden">
-        <div class="setting-group">
-          <h3>Content Scope</h3>
-          <label class="setting-option">
-            <input type="radio" name="contentScope" value="mainContent" checked> 
-            <span>Main article content only</span>
-          </label>
-          <label class="setting-option">
-            <input type="radio" name="contentScope" value="fullPage"> 
-            <span>Full page content</span>
-          </label>
-          <label class="setting-option">
-            <input type="radio" name="contentScope" value="selection"> 
-            <span>Selected text only</span>
-          </label>
+  <!-- Created by @jatinkrmalik (https://github.com/jatinkrmalik) -->
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLMFeeder</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+    />
+  </head>
+  <body>
+    <div class="container">
+      <header class="header">
+        <h1>LLMFeeder</h1>
+        <div class="active">
+          <div id="lightTheme">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="size-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+              />
+            </svg>
+          </div>
+          <div id="darkTheme">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="size-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+              />
+            </svg>
+          </div>
         </div>
-        
-        <div class="setting-group">
-          <h3>Formatting Options</h3>
-          <label class="setting-option">
-            <input type="checkbox" id="preserveTables" checked> 
-            <span>Preserve table formatting</span>
-          </label>
-          <label class="setting-option">
-            <input type="checkbox" id="includeImages" checked> 
-            <span>Include images</span>
-          </label>
-          <label class="setting-option">
-            <input type="checkbox" id="includeTitle" checked> 
-            <span>Include page title as heading</span>
-          </label>
-        </div>
-        
-        <div class="setting-group">
-          <h3>Keyboard Shortcuts</h3>
-          <div class="shortcut-info">
-            <div class="shortcut-row">
-              <span>Open Extension:</span>
-              <code id="popupShortcut">Alt+Shift+L</code>
-            </div>
-            <div class="shortcut-row">
-              <span>Quick Convert:</span>
-              <code id="quickConvertShortcut">Alt+Shift+M</code>
-            </div>
-            <div class="shortcut-customize">
-              <small>Customize at <code>chrome://extensions/shortcuts</code></small>
+        <p class="tagline">
+          Convert web pages to clean Markdown and copy to clipboard so you can
+          feed it to your favorite LLM model as context.
+        </p>
+      </header>
+
+      <div class="main-controls">
+        <button id="convertBtn" class="primary-btn">
+          <span class="btn-text">Convert & Copy</span>
+          <span id="convertShortcut" class="shortcut-badge"></span>
+        </button>
+        <div id="statusIndicator" class="status">Ready</div>
+      </div>
+
+      <div id="previewContainer" class="preview-container hidden">
+        <h2>Preview</h2>
+        <div id="previewContent" class="preview-content"></div>
+      </div>
+
+      <div
+        id="downloadMarkdownFileContainer"
+        class="download-markdown-file-container hidden"
+      >
+        <button id="downloadMarkdownFileBtn" class="primary-btn">
+          <span class="btn-text">Download As Markdown File</span>
+        </button>
+
+        <div id="downloadStatusIndicator" class="status"></div>
+      </div>
+
+      <div class="settings-section">
+        <button id="settingsToggleBtn" class="settings-toggle-btn">
+          <span class="btn-text">Settings</span>
+          <span class="toggle-icon">▼</span>
+        </button>
+
+        <div id="settingsContainer" class="settings-container hidden">
+          <div class="setting-group">
+            <h3>Content Scope</h3>
+            <label class="setting-option">
+              <input
+                type="radio"
+                name="contentScope"
+                value="mainContent"
+                checked
+              />
+              <span>Main article content only</span>
+            </label>
+            <label class="setting-option">
+              <input type="radio" name="contentScope" value="fullPage" />
+              <span>Full page content</span>
+            </label>
+            <label class="setting-option">
+              <input type="radio" name="contentScope" value="selection" />
+              <span>Selected text only</span>
+            </label>
+          </div>
+
+          <div class="setting-group">
+            <h3>Formatting Options</h3>
+            <label class="setting-option">
+              <input type="checkbox" id="preserveTables" checked />
+              <span>Preserve table formatting</span>
+            </label>
+            <label class="setting-option">
+              <input type="checkbox" id="includeImages" checked />
+              <span>Include images</span>
+            </label>
+            <label class="setting-option">
+              <input type="checkbox" id="includeTitle" checked />
+              <span>Include page title as heading</span>
+            </label>
+          </div>
+
+          <div class="setting-group">
+            <h3>Keyboard Shortcuts</h3>
+            <div class="shortcut-info">
+              <div class="shortcut-row">
+                <span>Open Extension:</span>
+                <code id="popupShortcut">Alt+Shift+L</code>
+              </div>
+              <div class="shortcut-row">
+                <span>Quick Convert:</span>
+                <code id="quickConvertShortcut">Alt+Shift+M</code>
+              </div>
+              <div class="shortcut-customize">
+                <small
+                  >Customize at
+                  <code>chrome://extensions/shortcuts</code></small
+                >
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  
-  <div class="footer">
-    <div>Made with ❤️ by <a href="https://x.com/jatinkrmalik" target="_blank">@jatinkrmalik</a></div>
-    <div class="github-link"><a href="https://github.com/jatinkrmalik/LLMFeeder" target="_blank">Contribute on GitHub</a></div>
-  </div>
-  <script src="libs/browser-polyfill.js"></script>
-  <script src="popup.js"></script>
-</body>
-</html> 
+
+    <div class="footer">
+      <div>
+        Made with ❤️ by
+        <a href="https://x.com/jatinkrmalik" target="_blank">@jatinkrmalik</a>
+      </div>
+      <div class="github-link">
+        <a href="https://github.com/jatinkrmalik/LLMFeeder" target="_blank"
+          >Contribute on GitHub</a
+        >
+      </div>
+    </div>
+    <script src="libs/browser-polyfill.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,28 +11,12 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
     />
   </head>
-  <body>
+  <body class="light-theme">
     <div class="container">
       <header class="header">
         <h1>LLMFeeder</h1>
-        <div class="active">
-          <div id="lightTheme">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="size-6"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-              />
-            </svg>
-          </div>
-          <div id="darkTheme">
+        <div class="theme-container">
+          <div class="dark-icon">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -48,13 +32,28 @@
               />
             </svg>
           </div>
+          <div class="light-icon hidden">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="size-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+              />
+            </svg>
+          </div>
         </div>
         <p class="tagline">
           Convert web pages to clean Markdown and copy to clipboard so you can
           feed it to your favorite LLM model as context.
         </p>
       </header>
-
       <div class="main-controls">
         <button id="convertBtn" class="primary-btn">
           <span class="btn-text">Convert & Copy</span>
@@ -78,7 +77,6 @@
 
         <div id="downloadStatusIndicator" class="status"></div>
       </div>
-
       <div class="settings-section">
         <button id="settingsToggleBtn" class="settings-toggle-btn">
           <span class="btn-text">Settings</span>
@@ -145,7 +143,6 @@
         </div>
       </div>
     </div>
-
     <div class="footer">
       <div>
         Made with ❤️ by

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,20 +102,37 @@ const downloadStatusIndicator = document.getElementById(
 );
 
 // DOM elements (theme)
-const lightIcon = document.querySelector(".light-icon");
-const darkIcon = document.querySelector(".dark-icon");
+const toogleLight = document.querySelector(".toggle-light");
+const toggleDark = document.querySelector(".toggle-dark");
 const bodyTag = document.querySelector("body");
-darkIcon.addEventListener("click", () => {
+
+toggleDark.addEventListener("click", () => {
   bodyTag.classList.remove("light-theme");
   bodyTag.classList.add("dark-theme");
-  darkIcon.classList.add("hidden");
-  lightIcon.classList.remove("hidden");
+  toggleDark.classList.add("hidden");
+  toogleLight.classList.remove("hidden");
+  localStorage.setItem("llmfeeder-theme", "dark");
 });
-lightIcon.addEventListener("click", () => {
+toogleLight.addEventListener("click", () => {
   bodyTag.classList.remove("dark-theme");
   bodyTag.classList.add("light-theme");
-  lightIcon.classList.add("hidden");
-  darkIcon.classList.remove("hidden");
+  toogleLight.classList.add("hidden");
+  toggleDark.classList.remove("hidden");
+  localStorage.setItem("llmfeeder-theme", "light");
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  if (localStorage.getItem("llmfeeder-theme")) {
+    if (localStorage.getItem("llmfeeder-theme") == "dark") {
+      bodyTag.classList.add("dark-theme");
+      toggleDark.classList.add("hidden");
+      toogleLight.classList.remove("hidden");
+    } else {
+      bodyTag.classList.add("light-theme");
+      toogleLight.classList.add("hidden");
+      toggleDark.classList.remove("hidden");
+    }
+  }
 });
 
 // Get all settings elements

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -101,113 +101,22 @@ const downloadStatusIndicator = document.getElementById(
   "downloadStatusIndicator"
 );
 
-
 // DOM elements (theme)
-const lightTheme = document.getElementById("lightTheme");
-const darkTheme = document.getElementById("darkTheme");
-const container = document.querySelector(".container");
-const tagLine = document.querySelector(".tagline");
-const tags = document.querySelectorAll("h3");
-const shortcutInfo = document.querySelector(".shortcut-info");
-const codeTags = document.querySelectorAll("code");
-const smallTag = document.querySelector("small");
-const footer = document.querySelector(".footer");
+const lightIcon = document.querySelector(".light-icon");
+const darkIcon = document.querySelector(".dark-icon");
 const bodyTag = document.querySelector("body");
-const githubLink = document.querySelector(".github-link a");
-
-// theme toggle
-lightTheme.addEventListener("click", () => {
-  lightTheme.style.display = "none";
-  darkTheme.style.display = "flex";
-  container.style.backgroundColor = "white";
-  container.style.color = "black";
-  tagLine.style.color = "var(--dark-gray)";
-  settingsToggleBtn.style.backgroundColor = "#313131";
-  tags.forEach((tag) => (tag.style.color = "var(--dark-gray)"));
-  settingsToggleBtn.style.backgroundColor = "#f1f3f4";
-  settingsToggleBtn.style.color = "black";
-  shortcutInfo.style.backgroundColor = "#f1f3f4";
-  shortcutInfo.style.color = "black";
-  shortcutInfo.style.borderColor = "#f1f3f4";
-  shortcutInfo.style.borderStyle = "solid";
-  shortcutInfo.style.borderWidth = "1px";
-  codeTags.forEach((tag) => {
-    tag.style.backgroundColor = "#f1f3f4";
-    tag.style.color = "black";
-  });
-  smallTag.style.color = "#5f6368";
-  previewContainer.style.backgroundColor = "#f1f3f4";
-  previewContainer.style.color = "black";
-  previewContainer.style.borderWidth = "1px";
-  previewContainer.style.borderStyle = "soild";
-  previewContent.style.color = "black";
-  previewContent.style.backgroundColor = "white";
-  previewContent.style.borderColor = "#f1f3f4";
-  previewContent.style.borderWidth = "1px";
-  previewContent.style.borderStyle = "solid";
-  footer.style.backgroundColor = "white";
-  footer.style.color = "#5f6368";
-  bodyTag.style.backgroundColor = "white";
-  githubLink.style.backgroundColor = "#f1f3f4";
-  githubLink.style.color = "#5f6368";
-  githubLink.style.borderColor = "#f1f3f4";
-  githubLink.style.borderStyle = "solid";
-  githubLink.style.borderWidth = "1px";
-  githubLink.addEventListener("mouseenter", () => {
-    githubLink.style.color = "#4285f4";
-  });
-  githubLink.addEventListener("mouseleave", () => {
-    githubLink.style.color = "#5f6368";
-  });
+darkIcon.addEventListener("click", () => {
+  bodyTag.classList.remove("light-theme");
+  bodyTag.classList.add("dark-theme");
+  darkIcon.classList.add("hidden");
+  lightIcon.classList.remove("hidden");
 });
-
-darkTheme.addEventListener("click", () => {
-  darkTheme.style.display = "none";
-  lightTheme.style.display = "flex";
-  container.style.backgroundColor = "#313131";
-  container.style.color = "white";
-  tagLine.style.color = "white";
-  tags.forEach((tag) => (tag.style.color = "white"));
-  settingsToggleBtn.style.backgroundColor = "#313131";
-  settingsToggleBtn.style.color = "white";
-  shortcutInfo.style.backgroundColor = "#313131";
-  shortcutInfo.style.color = "white";
-  shortcutInfo.style.borderColor = "#f1f3f4";
-  shortcutInfo.style.borderStyle = "solid";
-  shortcutInfo.style.borderWidth = "1px";
-  codeTags.forEach((tag) => {
-    tag.style.backgroundColor = "#313131";
-    tag.style.color = "white";
-  });
-  smallTag.style.color = "white";
-  previewContainer.style.backgroundColor = "#313131";
-  previewContainer.style.color = "white";
-  previewContainer.style.borderColor = "#f1f3f4";
-  previewContainer.style.borderStyle = "solid";
-  previewContainer.style.borderWidth = "1px";
-  previewContent.style.color = "white";
-  previewContent.style.backgroundColor = "#313131";
-  previewContent.style.borderColor = "#f1f3f4";
-  previewContent.style.borderStyle = "solid";
-  previewContent.style.borderWidth = "1px";
-  footer.style.backgroundColor = "#313131";
-  footer.style.color = "white";
-  bodyTag.style.backgroundColor = "#313131";
-  githubLink.style.backgroundColor = "#313131";
-  githubLink.style.color = "white";
-  githubLink.style.borderColor = "#f1f3f4";
-  githubLink.style.borderStyle = "solid";
-  githubLink.style.borderWidth = "1px";
-  githubLink.addEventListener("mouseenter", () => {
-    githubLink.style.color = "#4285f4";
-  });
-  githubLink.addEventListener("mouseleave", () => {
-    githubLink.style.color = "white";
-  });
+lightIcon.addEventListener("click", () => {
+  bodyTag.classList.remove("dark-theme");
+  bodyTag.classList.add("light-theme");
+  lightIcon.classList.add("hidden");
+  darkIcon.classList.remove("hidden");
 });
-
-
-
 
 // Get all settings elements
 const contentScopeRadios = document.querySelectorAll(
@@ -436,11 +345,14 @@ function downloadMarkdownFile(filename, content) {
     document.body.appendChild(a);
     a.click();
 
-    updateDownloadStatus('Download complete!', "success");
+    updateDownloadStatus("Download complete!", "success");
   } catch (error) {
     console.error("Error downloading file:", error);
 
-    updateDownloadStatus(`Error: ${error.message || "Failed to download file"}`, "error");
+    updateDownloadStatus(
+      `Error: ${error.message || "Failed to download file"}`,
+      "error"
+    );
   } finally {
     // Clean up, ensuring 'a' and 'url' are defined if an error occurred before their assignment
     if (a && a.parentElement) {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,37 +102,33 @@ const downloadStatusIndicator = document.getElementById(
 );
 
 // DOM elements (theme)
-const toogleLight = document.querySelector(".toggle-light");
+const toggleLight = document.querySelector(".toggle-light");
 const toggleDark = document.querySelector(".toggle-dark");
 const bodyTag = document.querySelector("body");
 
+const THEME_KEY = "llmfeeder-theme";
+const THEMES = { DARK: "dark", LIGHT: "light" };
+
+function setTheme(theme) {
+  const isDark = theme === THEMES.DARK;
+  bodyTag.classList.toggle("dark-theme", isDark);
+  bodyTag.classList.toggle("light-theme", !isDark);
+  toggleDark.classList.toggle("hidden", isDark);
+  toggleLight.classList.toggle("hidden", !isDark);
+  localStorage.setItem(THEME_KEY, theme);
+}
+
 toggleDark.addEventListener("click", () => {
-  bodyTag.classList.remove("light-theme");
-  bodyTag.classList.add("dark-theme");
-  toggleDark.classList.add("hidden");
-  toogleLight.classList.remove("hidden");
-  localStorage.setItem("llmfeeder-theme", "dark");
+  setTheme("dark");
 });
-toogleLight.addEventListener("click", () => {
-  bodyTag.classList.remove("dark-theme");
-  bodyTag.classList.add("light-theme");
-  toogleLight.classList.add("hidden");
-  toggleDark.classList.remove("hidden");
-  localStorage.setItem("llmfeeder-theme", "light");
+toggleLight.addEventListener("click", () => {
+  setTheme("light");
 });
 
+let userThemePreference = localStorage.getItem("llmfeeder-theme");
 window.addEventListener("DOMContentLoaded", () => {
-  if (localStorage.getItem("llmfeeder-theme")) {
-    if (localStorage.getItem("llmfeeder-theme") == "dark") {
-      bodyTag.classList.add("dark-theme");
-      toggleDark.classList.add("hidden");
-      toogleLight.classList.remove("hidden");
-    } else {
-      bodyTag.classList.add("light-theme");
-      toogleLight.classList.add("hidden");
-      toggleDark.classList.remove("hidden");
-    }
-  }
+  if (userThemePreference === "dark" || userThemePreference === "light")
+    setTheme(userThemePreference);
 });
 
 // Get all settings elements

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -101,6 +101,114 @@ const downloadStatusIndicator = document.getElementById(
   "downloadStatusIndicator"
 );
 
+
+// DOM elements (theme)
+const lightTheme = document.getElementById("lightTheme");
+const darkTheme = document.getElementById("darkTheme");
+const container = document.querySelector(".container");
+const tagLine = document.querySelector(".tagline");
+const tags = document.querySelectorAll("h3");
+const shortcutInfo = document.querySelector(".shortcut-info");
+const codeTags = document.querySelectorAll("code");
+const smallTag = document.querySelector("small");
+const footer = document.querySelector(".footer");
+const bodyTag = document.querySelector("body");
+const githubLink = document.querySelector(".github-link a");
+
+// theme toggle
+lightTheme.addEventListener("click", () => {
+  lightTheme.style.display = "none";
+  darkTheme.style.display = "flex";
+  container.style.backgroundColor = "white";
+  container.style.color = "black";
+  tagLine.style.color = "var(--dark-gray)";
+  settingsToggleBtn.style.backgroundColor = "#313131";
+  tags.forEach((tag) => (tag.style.color = "var(--dark-gray)"));
+  settingsToggleBtn.style.backgroundColor = "#f1f3f4";
+  settingsToggleBtn.style.color = "black";
+  shortcutInfo.style.backgroundColor = "#f1f3f4";
+  shortcutInfo.style.color = "black";
+  shortcutInfo.style.borderColor = "#f1f3f4";
+  shortcutInfo.style.borderStyle = "solid";
+  shortcutInfo.style.borderWidth = "1px";
+  codeTags.forEach((tag) => {
+    tag.style.backgroundColor = "#f1f3f4";
+    tag.style.color = "black";
+  });
+  smallTag.style.color = "#5f6368";
+  previewContainer.style.backgroundColor = "#f1f3f4";
+  previewContainer.style.color = "black";
+  previewContainer.style.borderWidth = "1px";
+  previewContainer.style.borderStyle = "soild";
+  previewContent.style.color = "black";
+  previewContent.style.backgroundColor = "white";
+  previewContent.style.borderColor = "#f1f3f4";
+  previewContent.style.borderWidth = "1px";
+  previewContent.style.borderStyle = "solid";
+  footer.style.backgroundColor = "white";
+  footer.style.color = "#5f6368";
+  bodyTag.style.backgroundColor = "white";
+  githubLink.style.backgroundColor = "#f1f3f4";
+  githubLink.style.color = "#5f6368";
+  githubLink.style.borderColor = "#f1f3f4";
+  githubLink.style.borderStyle = "solid";
+  githubLink.style.borderWidth = "1px";
+  githubLink.addEventListener("mouseenter", () => {
+    githubLink.style.color = "#4285f4";
+  });
+  githubLink.addEventListener("mouseleave", () => {
+    githubLink.style.color = "#5f6368";
+  });
+});
+
+darkTheme.addEventListener("click", () => {
+  darkTheme.style.display = "none";
+  lightTheme.style.display = "flex";
+  container.style.backgroundColor = "#313131";
+  container.style.color = "white";
+  tagLine.style.color = "white";
+  tags.forEach((tag) => (tag.style.color = "white"));
+  settingsToggleBtn.style.backgroundColor = "#313131";
+  settingsToggleBtn.style.color = "white";
+  shortcutInfo.style.backgroundColor = "#313131";
+  shortcutInfo.style.color = "white";
+  shortcutInfo.style.borderColor = "#f1f3f4";
+  shortcutInfo.style.borderStyle = "solid";
+  shortcutInfo.style.borderWidth = "1px";
+  codeTags.forEach((tag) => {
+    tag.style.backgroundColor = "#313131";
+    tag.style.color = "white";
+  });
+  smallTag.style.color = "white";
+  previewContainer.style.backgroundColor = "#313131";
+  previewContainer.style.color = "white";
+  previewContainer.style.borderColor = "#f1f3f4";
+  previewContainer.style.borderStyle = "solid";
+  previewContainer.style.borderWidth = "1px";
+  previewContent.style.color = "white";
+  previewContent.style.backgroundColor = "#313131";
+  previewContent.style.borderColor = "#f1f3f4";
+  previewContent.style.borderStyle = "solid";
+  previewContent.style.borderWidth = "1px";
+  footer.style.backgroundColor = "#313131";
+  footer.style.color = "white";
+  bodyTag.style.backgroundColor = "#313131";
+  githubLink.style.backgroundColor = "#313131";
+  githubLink.style.color = "white";
+  githubLink.style.borderColor = "#f1f3f4";
+  githubLink.style.borderStyle = "solid";
+  githubLink.style.borderWidth = "1px";
+  githubLink.addEventListener("mouseenter", () => {
+    githubLink.style.color = "#4285f4";
+  });
+  githubLink.addEventListener("mouseleave", () => {
+    githubLink.style.color = "white";
+  });
+});
+
+
+
+
 // Get all settings elements
 const contentScopeRadios = document.querySelectorAll(
   'input[name="contentScope"]'

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -58,19 +58,32 @@ body {
   position: relative;
 }
 .theme-container{
+  all:unset;
+  width: 40px;
+  height: 40px;
   position: absolute;
   right: 2px;
   top:2px;
+}
+.toggle-dark{
+  all:unset;
+  width: 35px;
+  height: 35px;
+  position: absolute;
+  right:4px;
+  top: 4px;
   cursor: pointer;
 }
-.dark-icon{
-  width: 35px;
-  height: 35px;
-}
 
-.light-icon{
+.toggle-light{
+  all:unset;
   width: 35px;
   height: 35px;
+  position: absolute;
+  right:4px;
+  top: 4px;
+  cursor: pointer;
+
 }
 .hidden{
   display: none;

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -249,7 +249,7 @@ h3 {
   border-radius: 4px;
   border: 1px solid var(--border-color);
   color:var(--text-color);
-  background-color: var(--background-color)
+  background-color: var(--background-color);
 }
 
 .settings-section {

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -12,6 +12,30 @@
   --success-color: #34a853;
   --error-color: #ea4335;
   --warning-color: #fbbc04;
+  --setting-hover: #e8eaed;
+  --github-link-hover: #e8eaed;
+  --github-link-border: rgb(229, 227, 227);
+}
+
+.light-theme {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --light-gray: #f1f3f4;
+  --dark-gray: #5f6368;
+  --setting-hover: #e8eaed;
+  --github-link-hover: #e8eaed;
+  --github-link-border: rgb(229, 227, 227);
+}
+
+.dark-theme {
+  --background-color: #313131;
+  --text-color: #f1f1f1;
+  --light-gray: #313131;
+  --dark-gray: #f1f1f1;
+  --setting-hover: #8c8989;
+  --github-link-border: #f1f1f1;
+  --github-link-hover: rgb(70, 68, 68);
+  --preview-containter-border: #ffffff;
 }
 
 body {
@@ -21,6 +45,7 @@ body {
   color: var(--text-color);
   background-color: var(--background-color);
   line-height: 1.5;
+  transition: all 0.3s ease;
 }
 
 .container {
@@ -32,25 +57,23 @@ body {
   margin-bottom: 20px;
   position: relative;
 }
-.active{
+.theme-container{
   position: absolute;
-  top: 4px;
   right: 2px;
-  width: fit-content;
-  height: fit-content;
-  padding: 3px 3px 3px 3px;
+  top:2px;
   cursor: pointer;
 }
-#lightTheme{
-  display: none;
-  width: 25px;
-  height: 25px;
+.dark-icon{
+  width: 35px;
+  height: 35px;
 }
 
-#darkTheme{
-  display: flex;
-  width: 25px;
-  height: 25px;
+.light-icon{
+  width: 35px;
+  height: 35px;
+}
+.hidden{
+  display: none;
 }
 
 h1 {
@@ -188,9 +211,11 @@ h3 {
 
 .preview-container {
   background-color: var(--light-gray);
+  color: var(--text-color);
   border-radius: 8px;
   padding: 16px;
   margin-bottom: 20px;
+  border:1px solid var(--border-color);
   animation: slideDown 0.3s ease-out;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -208,9 +233,10 @@ h3 {
   white-space: pre-wrap;
   word-break: break-word;
   padding: 8px;
-  background-color: white;
   border-radius: 4px;
   border: 1px solid var(--border-color);
+  color:var(--text-color);
+  background-color: var(--background-color)
 }
 
 .settings-section {
@@ -230,10 +256,11 @@ h3 {
   align-items: center;
   justify-content: space-between;
   transition: background-color 0.2s;
+  color: var(--text-color);
 }
 
 .settings-toggle-btn:hover {
-  background-color: #e8eaed;
+  background-color: var(--setting-hover);
 }
 
 .toggle-icon {
@@ -298,7 +325,7 @@ input[type="checkbox"] {
 }
 
 .shortcut-row code {
-  background-color: white;
+  background-color: var(--background-color);
   padding: 2px 5px;
   border-radius: 3px;
   font-family: 'Roboto Mono', monospace;
@@ -313,7 +340,7 @@ input[type="checkbox"] {
 }
 
 .shortcut-customize code {
-  background-color: #f5f5f5;
+  background-color: var(--background-color);
   padding: 1px 4px;
   border-radius: 3px;
   font-family: 'Roboto Mono', monospace;
@@ -364,11 +391,12 @@ input[type="checkbox"] {
   background-color: var(--light-gray);
   padding: 3px 8px;
   border-radius: 12px;
+  border:1px solid var(--github-link-border);
   transition: all 0.2s ease;
 }
 
 .github-link a:hover {
-  background-color: #e8eaed;
+  background-color: var(--github-link-hover);
   color: var(--primary-color);
   text-decoration: none;
 } 

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -30,6 +30,27 @@ body {
 
 .header {
   margin-bottom: 20px;
+  position: relative;
+}
+.active{
+  position: absolute;
+  top: 4px;
+  right: 2px;
+  width: fit-content;
+  height: fit-content;
+  padding: 3px 3px 3px 3px;
+  cursor: pointer;
+}
+#lightTheme{
+  display: none;
+  width: 25px;
+  height: 25px;
+}
+
+#darkTheme{
+  display: flex;
+  width: 25px;
+  height: 25px;
 }
 
 h1 {


### PR DESCRIPTION
1. Initially added two <svg> tags for dark and light mode in pop.html.
2. Targeted all the required elements in the DOM and applied styling using DOM manipulation.
3. added a "active" class in the styles.css which include both the icons for dark and light theme.

https://github.com/user-attachments/assets/309d2324-4b36-4960-970d-a53ef837e9b2

- Dark Theme
![d1](https://github.com/user-attachments/assets/854fc571-5381-4ab3-aed7-4c9c1d31b284)
![d2](https://github.com/user-attachments/assets/fb12f965-ec2b-4aac-8126-e22fbec18bea)

- Light Theme
![l1](https://github.com/user-attachments/assets/febe6a24-6ba6-4862-b86d-12cfe45c53c4)
![l2](https://github.com/user-attachments/assets/7a00875e-13b2-4806-b527-68e6435cfca7)

