### PR TITLE
fix: Cross browser notification popup for copy shortcut

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -88,6 +88,13 @@
       }
       return true; // Indicates we will send a response asynchronously
     }
+    
+    // Show notification handler
+    if (request.action === 'showNotification') {
+      showNotification(request.title, request.message);
+      sendResponse({ success: true });
+      return true;
+    }
   });
   
   /**
@@ -457,5 +464,54 @@
         }
       });
     };
+  }
+
+  /**
+   * Show notification in the current tab
+   * @param {string} title - Notification title
+   * @param {string} message - Notification message
+   */
+  function showNotification(title, message) {
+    // Create notification element
+    const notification = document.createElement('div');
+    notification.style.position = 'fixed';
+    notification.style.top = '20px';
+    notification.style.right = '20px';
+    notification.style.backgroundColor = '#fff';
+    notification.style.border = '1px solid #ccc';
+    notification.style.borderRadius = '4px';
+    notification.style.boxShadow = '0 2px 10px rgba(0,0,0,0.2)';
+    notification.style.padding = '10px 15px';
+    notification.style.zIndex = '9999';
+    notification.style.maxWidth = '300px';
+    notification.style.fontFamily = 'Roboto, Arial, sans-serif';
+    
+    // Add title
+    const titleElement = document.createElement('h3');
+    titleElement.textContent = title;
+    titleElement.style.margin = '0 0 5px 0';
+    titleElement.style.fontSize = '16px';
+    notification.appendChild(titleElement);
+    
+    // Add message
+    const messageElement = document.createElement('p');
+    messageElement.textContent = message;
+    messageElement.style.margin = '0';
+    messageElement.style.fontSize = '14px';
+    notification.appendChild(messageElement);
+    
+    // Add to page
+    document.body.appendChild(notification);
+    
+    // Remove after 3 seconds
+    setTimeout(() => {
+      notification.style.opacity = '0';
+      notification.style.transition = 'opacity 0.5s';
+      setTimeout(() => {
+        if (notification.parentNode) {
+          notification.parentNode.removeChild(notification);
+        }
+      }, 500);
+    }, 3000);
   }
 })(); 

--- a/extension/content.js
+++ b/extension/content.js
@@ -503,10 +503,12 @@
     // Add to page
     document.body.appendChild(notification);
     
+    // Set transition property for smooth fade-out
+    notification.style.transition = 'opacity 0.5s';
+    
     // Remove after 3 seconds
     setTimeout(() => {
       notification.style.opacity = '0';
-      notification.style.transition = 'opacity 0.5s';
       setTimeout(() => {
         if (notification.parentNode) {
           notification.parentNode.removeChild(notification);


### PR DESCRIPTION
<!--

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

fix: #42 

## Changes Made

- fix the popup when quick copy shortcut is used in in cross browsers ( Chrome, Firefox ).
- Use native browser api instead of Chome browser api

## Test URLs

https://en.wikipedia.org/wiki/Grafana

## Screenshot

### FireFox

<img width="1440" alt="Screenshot 2025-06-08 at 5 16 49 PM" src="https://github.com/user-attachments/assets/beb90d9a-b571-45f2-9856-c1c3c6b6e19f" />

### Chrome

<img width="1440" alt="Screenshot 2025-06-08 at 5 16 22 PM" src="https://github.com/user-attachments/assets/ba45a2b6-3270-4e5d-affa-5e9d095758a9" />

### Screen Capture Demo in both browsers


https://github.com/user-attachments/assets/628a0201-278a-4d82-a523-c3e8d1b56e61

