### PR TITLE
feat: Add 'Include Links' toggle option

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -319,7 +319,8 @@
       contentScope: settings.contentScope,
       preserveTables: settings.preserveTables,
       includeImages: settings.includeImages,
-      includeTitle: settings.includeTitle
+      includeTitle: settings.includeTitle,
+      includeLinks: settings.includeLinks
     });
 
     const docClone = document.cloneNode(true);
@@ -1003,6 +1004,17 @@
         filter: 'img',
         replacement: function() {
           return '';
+        }
+      });
+    }
+
+    if (!settings.includeLinks) {
+      turndownService.addRule('stripLinks', {
+        filter: function(node) {
+          return node.nodeName === 'A' && node.href;
+        },
+        replacement: function(content, node) {
+          return content;
         }
       });
     }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -245,6 +245,10 @@
                 <input type="checkbox" id="includeTitle" checked />
                 <span>Include page title as heading</span>
               </label>
+              <label class="setting-option">
+                <input type="checkbox" id="includeLinks" checked />
+                <span>Include links in markdown</span>
+              </label>
             </div>
 
             <div class="setting-group">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -125,6 +125,7 @@ const contentScopeRadios = document.querySelectorAll('input[name="contentScope"]
 const preserveTablesCheckbox = document.getElementById("preserveTables");
 const includeImagesCheckbox = document.getElementById("includeImages");
 const includeTitleCheckbox = document.getElementById("includeTitle");
+const includeLinksCheckbox = document.getElementById("includeLinks");
 const includeMetadataCheckbox = document.getElementById("includeMetadata");
 const metadataFormatTextarea = document.getElementById("metadataFormat");
 const metadataFormatContainer = document.getElementById("metadataFormatContainer");
@@ -355,6 +356,7 @@ async function loadSettings() {
     preserveTablesCheckbox.checked = data.preserveTables;
     includeImagesCheckbox.checked = data.includeImages;
     includeTitleCheckbox.checked = data.includeTitle;
+    includeLinksCheckbox.checked = data.includeLinks !== false;
     includeMetadataCheckbox.checked = data.includeMetadata;
     metadataFormatTextarea.value = data.metadataFormat;
     debugModeCheckbox.checked = data.debugMode;
@@ -380,6 +382,7 @@ async function saveSettings() {
     const preserveTables = preserveTablesCheckbox.checked;
     const includeImages = includeImagesCheckbox.checked;
     const includeTitle = includeTitleCheckbox.checked;
+    const includeLinks = includeLinksCheckbox.checked;
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
@@ -391,6 +394,7 @@ async function saveSettings() {
       preserveTables,
       includeImages,
       includeTitle,
+      includeLinks,
       includeMetadata,
       metadataFormat,
       debugMode,
@@ -822,6 +826,7 @@ async function convertToMarkdown() {
     const preserveTables = preserveTablesCheckbox.checked;
     const includeImages = includeImagesCheckbox.checked;
     const includeTitle = includeTitleCheckbox.checked;
+    const includeLinks = includeLinksCheckbox.checked;
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
@@ -834,6 +839,7 @@ async function convertToMarkdown() {
         preserveTables,
         includeImages,
         includeTitle,
+        includeLinks,
         includeMetadata,
         metadataFormat,
         debugMode,
@@ -904,6 +910,7 @@ async function downloadMarkdown() {
     const preserveTables = preserveTablesCheckbox.checked;
     const includeImages = includeImagesCheckbox.checked;
     const includeTitle = includeTitleCheckbox.checked;
+    const includeLinks = includeLinksCheckbox.checked;
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
@@ -916,6 +923,7 @@ async function downloadMarkdown() {
         preserveTables,
         includeImages,
         includeTitle,
+        includeLinks,
         includeMetadata,
         metadataFormat,
         debugMode,
@@ -1006,6 +1014,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   preserveTablesCheckbox.addEventListener("change", saveSettings);
   includeImagesCheckbox.addEventListener("change", saveSettings);
   includeTitleCheckbox.addEventListener("change", saveSettings);
+  includeLinksCheckbox.addEventListener("change", saveSettings);
   debugModeCheckbox.addEventListener("change", () => {
     updateDebugModeVisibility();
     saveSettings();

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -12,6 +12,7 @@ const SettingsUtils = (function() {
       preserveTables: true,
       includeImages: true,
       includeTitle: true,
+      includeLinks: true,
       includeMetadata: true,
       metadataFormat: DEFAULT_METADATA_FORMAT,
       debugMode: false

--- a/testbench.html
+++ b/testbench.html
@@ -176,5 +176,21 @@
         <div class="expected"><span class="success">Expected:</span> Empty cells handled correctly with |</div>
     </div>
 
+    <div class="test-section">
+        <h2>Test 9: Links (Include Links Toggle)</h2>
+        <p>This section tests the "Include Links" toggle setting:</p>
+        <ul>
+            <li><a href="https://github.com/jatinkrmalik/LLMFeeder">Link to GitHub repository</a> - external link</li>
+            <li><a href="#test-section-1">Link to Test 1 (anchor)</a> - internal anchor link</li>
+            <li><a href="/about">Relative link to about page</a> - relative link</li>
+            <li><a href="mailto:test@example.com">Email link</a> - mailto protocol</li>
+            <li>Nested link: <a href="https://example.com">This has <strong>bold</strong> and <em>italic</em> text</a></li>
+            <li><a href="https://en.wikipedia.org/wiki/Markdown">Wikipedia article about Markdown</a></li>
+            <li><a href="https://developer.mozilla.org/en-US/">MDN Web Docs</a></li>
+        </ul>
+        <div class="expected"><span class="success">Expected (Include Links ON):</span> Links as <code>[text](url)</code></div>
+        <div class="expected"><span class="warning">Expected (Include Links OFF):</span> Only text, no URLs</div>
+    </div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a new checkbox under **Formatting Options** that allows users to control whether webpage links are preserved in Markdown output.

### What's New

Updated `testbench.html`: 
<img width="1281" height="566" alt="image" src="https://github.com/user-attachments/assets/04099f40-a89a-4fc0-85c9-e9e726b33296" />

With links ✅ / Without links ❌
<img width="3291" height="1267" alt="image" src="https://github.com/user-attachments/assets/d1985bf0-1f34-45df-bbc4-5ba21f8127ab" />

New formatting option:
<img width="445" height="227" alt="image" src="https://github.com/user-attachments/assets/8db0d5a4-3f31-49da-88f7-dad51a5ae653" />

- **"Include links in markdown"** checkbox (default: ON)
- When **enabled**: Links preserved as `[text](url)` format (current behavior)
- When **disabled**: Only link text retained, URLs stripped
- Setting persists across popup sessions

### User Benefits

- Reduce token usage when links aren't needed for LLM context
- Cleaner Markdown output for specific use cases
- Maintains backward compatibility with default ON state

### Testing

Tested on both Chrome and Firefox:
- ✅ Toggle persists after popup close/reopen
- ✅ Links preserved when checked
- ✅ Links stripped when unchecked
- ✅ Nested formatting (bold/italic) preserved
- ✅ Works with all content scopes

Resolves #84