### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,6 @@ Thanks a lot for spending your time helping LLMFeeder grow.🍻
 
 [![Contributors](https://contrib.rocks/image?repo=jatinkrmalik/LLMFeeder)](https://github.com/jatinkrmalik/LLMFeeder/graphs/contributors)
 
-## Star History
+## Star Chart
 
 [![Star History Chart](https://api.star-history.com/svg?repos=jatinkrmalik/LLMFeeder&type=Date)](https://star-history.com/#jatinkrmalik/LLMFeeder&Date)

--- a/README.md
+++ b/README.md
@@ -407,3 +407,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 Thanks a lot for spending your time helping LLMFeeder grow.🍻
 
 [![Contributors](https://contrib.rocks/image?repo=jatinkrmalik/LLMFeeder)](https://github.com/jatinkrmalik/LLMFeeder/graphs/contributors)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=jatinkrmalik/LLMFeeder&type=Date)](https://star-history.com/#jatinkrmalik/LLMFeeder&Date)


### PR DESCRIPTION
## Summary

- Adds a **Star History** section at the end of the README with an auto-updating chart from [star-history.com](https://star-history.com)
- The chart renders as an SVG that shows stars over time, and links to the interactive view
- Placed after the Contributors section to keep it as the final visual element