### PR TITLE
feat: add alternative copy mode to copy button

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -71,14 +71,14 @@
               <!-- Single-tab actions -->
               <div id="singleTabActions" class="action-buttons">
                 <div id="convertSplit" class="split-btn">
-                  <button id="convertBtn" class="primary-btn split-btn-main" title="Convert this page to Markdown and copy to clipboard">
+                  <button id="convertBtn" class="primary-btn split-btn-main" type="button" title="Convert this page to Markdown and copy to clipboard">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="btn-icon">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
                     </svg>
                     <span class="btn-text">Convert & Copy</span>
                     <span id="convertShortcut" class="shortcut-badge"></span>
                   </button>
-                  <button id="convertMenuBtn" class="primary-btn split-btn-caret" type="button" title="More copy options" aria-haspopup="true" aria-expanded="false" aria-controls="convertMenu">
+                  <button id="convertMenuBtn" class="primary-btn split-btn-caret" type="button" title="More copy options" aria-haspopup="menu" aria-expanded="false" aria-controls="convertMenu">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="caret-icon">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -70,13 +70,28 @@
             <div class="main-controls">
               <!-- Single-tab actions -->
               <div id="singleTabActions" class="action-buttons">
-                <button id="convertBtn" class="primary-btn" title="Convert this page to Markdown and copy to clipboard">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="btn-icon">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
-                  </svg>
-                  <span class="btn-text">Convert & Copy</span>
-                  <span id="convertShortcut" class="shortcut-badge"></span>
-                </button>
+                <div id="convertSplit" class="split-btn">
+                  <button id="convertBtn" class="primary-btn split-btn-main" title="Convert this page to Markdown and copy to clipboard">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="btn-icon">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
+                    </svg>
+                    <span class="btn-text">Convert & Copy</span>
+                    <span id="convertShortcut" class="shortcut-badge"></span>
+                  </button>
+                  <button id="convertMenuBtn" class="primary-btn split-btn-caret" type="button" title="More copy options" aria-haspopup="true" aria-expanded="false" aria-controls="convertMenu">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="caret-icon">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                    </svg>
+                  </button>
+                  <div id="convertMenu" class="split-btn-menu hidden" role="menu" aria-labelledby="convertMenuBtn">
+                    <button id="convertOverrideBtn" class="split-btn-menu-item" type="button" role="menuitem">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="menu-item-icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                      <span class="override-label">Copy full page</span>
+                    </button>
+                  </div>
+                </div>
                 <button id="downloadBtn" class="secondary-btn" title="Convert this page to Markdown and download as a file">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="btn-icon">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -78,13 +78,13 @@
                     <span class="btn-text">Convert & Copy</span>
                     <span id="convertShortcut" class="shortcut-badge"></span>
                   </button>
-                  <button id="convertMenuBtn" class="primary-btn split-btn-caret" type="button" title="More copy options" aria-haspopup="menu" aria-expanded="false" aria-controls="convertMenu">
+                  <button id="convertMenuBtn" class="primary-btn split-btn-caret" type="button" aria-label="More copy options" title="More copy options" aria-haspopup="true" aria-expanded="false" aria-controls="convertMenu">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="caret-icon">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
                   </button>
-                  <div id="convertMenu" class="split-btn-menu hidden" role="menu" aria-labelledby="convertMenuBtn">
-                    <button id="convertOverrideBtn" class="split-btn-menu-item" type="button" role="menuitem">
+                  <div id="convertMenu" class="split-btn-menu hidden" aria-labelledby="convertMenuBtn">
+                    <button id="convertOverrideBtn" class="split-btn-menu-item" type="button">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="menu-item-icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                       </svg>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -88,6 +88,11 @@ const browserAPI = (function () {
 
 // DOM elements - Main view
 const convertBtn = document.getElementById("convertBtn");
+const convertSplit = document.getElementById("convertSplit");
+const convertMenuBtn = document.getElementById("convertMenuBtn");
+const convertMenu = document.getElementById("convertMenu");
+const convertOverrideBtn = document.getElementById("convertOverrideBtn");
+const convertOverrideLabel = convertOverrideBtn ? convertOverrideBtn.querySelector(".override-label") : null;
 const downloadBtn = document.getElementById("downloadBtn");
 const downloadBtnShortcut = document.getElementById("downloadBtnShortcut");
 const statusIndicator = document.getElementById("statusIndicator");
@@ -807,7 +812,7 @@ async function downloadZipArchive() {
 }
 
 // Convert current page to Markdown
-async function convertToMarkdown() {
+async function convertToMarkdown(scopeOverride) {
   statusIndicator.textContent = "Converting...";
   statusIndicator.className = "status processing";
 
@@ -821,8 +826,8 @@ async function convertToMarkdown() {
       throw new Error("No active tab found");
     }
 
-    // Get current settings
-    const contentScope = document.querySelector('input[name="contentScope"]:checked').value;
+    // Get current settings (scopeOverride bypasses the saved contentScope for one conversion)
+    const contentScope = scopeOverride || document.querySelector('input[name="contentScope"]:checked').value;
     const preserveTables = preserveTablesCheckbox.checked;
     const includeImages = includeImagesCheckbox.checked;
     const includeTitle = includeTitleCheckbox.checked;
@@ -975,6 +980,47 @@ async function downloadMarkdown() {
   }
 }
 
+// Convert split-button menu helpers
+function updateConvertSplitVisibility() {
+  const checked = document.querySelector('input[name="contentScope"]:checked');
+  const scope = checked ? checked.value : "mainContent";
+
+  // Caret offers the opposite of the saved scope. Selection scope has no useful inverse.
+  if (scope === "mainContent") {
+    convertSplit.classList.remove("no-menu");
+    convertOverrideLabel.textContent = "Copy full page";
+    convertOverrideBtn.title = "Override the Main-content-only setting and copy the full page this once";
+    convertOverrideBtn.dataset.scope = "fullPage";
+  } else if (scope === "fullPage") {
+    convertSplit.classList.remove("no-menu");
+    convertOverrideLabel.textContent = "Copy main content only";
+    convertOverrideBtn.title = "Override the Full-page setting and copy main content only this once";
+    convertOverrideBtn.dataset.scope = "mainContent";
+  } else {
+    convertSplit.classList.add("no-menu");
+    closeConvertMenu();
+  }
+}
+
+function openConvertMenu() {
+  convertMenu.classList.remove("hidden");
+  convertMenuBtn.setAttribute("aria-expanded", "true");
+  convertOverrideBtn.focus();
+}
+
+function closeConvertMenu() {
+  convertMenu.classList.add("hidden");
+  convertMenuBtn.setAttribute("aria-expanded", "false");
+}
+
+function toggleConvertMenu() {
+  if (convertMenu.classList.contains("hidden")) {
+    openConvertMenu();
+  } else {
+    closeConvertMenu();
+  }
+}
+
 // Event Listeners
 document.addEventListener("DOMContentLoaded", async () => {
   initTheme();
@@ -990,8 +1036,41 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   // Single-tab button clicks
-  convertBtn.addEventListener("click", convertToMarkdown);
+  convertBtn.addEventListener("click", () => {
+    closeConvertMenu();
+    convertToMarkdown();
+  });
   downloadBtn.addEventListener("click", downloadMarkdown);
+
+  // Convert split-button menu (override contentScope for one-shot full-page copy)
+  updateConvertSplitVisibility();
+  contentScopeRadios.forEach((radio) => {
+    radio.addEventListener("change", updateConvertSplitVisibility);
+  });
+
+  convertMenuBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggleConvertMenu();
+  });
+
+  convertOverrideBtn.addEventListener("click", () => {
+    const override = convertOverrideBtn.dataset.scope || "fullPage";
+    closeConvertMenu();
+    convertToMarkdown(override);
+  });
+
+  document.addEventListener("click", (e) => {
+    if (!convertMenu.classList.contains("hidden") && !convertSplit.contains(e.target)) {
+      closeConvertMenu();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !convertMenu.classList.contains("hidden")) {
+      closeConvertMenu();
+      convertMenuBtn.focus();
+    }
+  });
 
   // Multi-tab button clicks
   copyAllBtn.addEventListener("click", copyAllTabs);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1072,6 +1072,13 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
+  // Close the menu when focus leaves the split-button container (e.g. user tabs away)
+  convertSplit.addEventListener("focusout", (e) => {
+    if (!convertSplit.contains(e.relatedTarget)) {
+      closeConvertMenu();
+    }
+  });
+
   // Multi-tab button clicks
   copyAllBtn.addEventListener("click", copyAllTabs);
   downloadMergedBtn.addEventListener("click", downloadMergedFile);

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -364,6 +364,104 @@ h3 {
   flex-shrink: 0;
 }
 
+/* Split button (Convert & Copy + dropdown) */
+.split-btn {
+  position: relative;
+  display: flex;
+  width: 100%;
+}
+
+.split-btn .primary-btn {
+  width: auto;
+}
+
+.split-btn-main {
+  flex: 1 1 auto;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.split-btn-caret {
+  flex: 0 0 auto;
+  padding: 12px 10px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.split-btn-caret:hover {
+  transform: none;
+}
+
+.split-btn-main:hover {
+  transform: none;
+}
+
+.split-btn:hover .split-btn-main,
+.split-btn:hover .split-btn-caret {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.caret-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.split-btn-caret[aria-expanded="true"] .caret-icon {
+  transform: rotate(180deg);
+}
+
+.split-btn.no-menu .split-btn-caret,
+.split-btn.no-menu .split-btn-menu {
+  display: none;
+}
+
+.split-btn.no-menu .split-btn-main {
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+.split-btn-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 200px;
+  background-color: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+  padding: 4px;
+  z-index: 10;
+}
+
+.split-btn-menu-item {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.split-btn-menu-item:hover,
+.split-btn-menu-item:focus-visible {
+  background-color: var(--setting-hover);
+}
+
+.menu-item-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--primary-color);
+  flex-shrink: 0;
+}
+
 .status {
   margin-top: 12px;
   font-size: 14px;

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -450,9 +450,19 @@ h3 {
   transition: background-color 0.15s ease;
 }
 
-.split-btn-menu-item:hover,
+.split-btn-menu-item:hover {
+  background-color: var(--setting-hover);
+}
+
 .split-btn-menu-item:focus-visible {
   background-color: var(--setting-hover);
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+.split-btn-caret:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .menu-item-icon {


### PR DESCRIPTION
<!--

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualise this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

I often find myself going into the settings to change the default copy behaviour from copy main article to copy full page content and then forgetting to change it back. This PR adds a small carrot on the right of the copy button to shows a sub-menu button with the option to copy full page content and vice versa when the user has the default copy behaviour set to copy full page content.

## Changes Made

- Add but dropdown to copy full page content without the need to change the default copy behaviour and vice versa.

## Test URLs

N/A (UI element only, uses existing logic)

## Screenshot

<img width="294" height="66" alt="image" src="https://github.com/user-attachments/assets/c3cabe6d-26dc-4f19-a4f5-e2a48109c67f" />

Clicking the carrot on the right gives the option to copy the full page content:

<img width="291" height="130" alt="image" src="https://github.com/user-attachments/assets/d41e1537-1c60-44d3-8206-9cabfbd0ddaf" />

And if you have copy full page content as the default behaviour, it's reversed:

<img width="318" height="142" alt="image" src="https://github.com/user-attachments/assets/a8c69f23-8304-4d5c-b65f-7a8334c9f9b9" />
