### PR TITLE
fix #66: parse generic preformatted elements as code

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1021,20 +1021,35 @@
 
     turndownService.addRule('fencedCodeBlock', {
       filter: function(node) {
-        return (
-          node.nodeName === 'PRE' &&
-          node.firstChild &&
-          node.firstChild.nodeName === 'CODE'
-        );
+        return node.nodeName === 'PRE';
       },
       replacement: function(content, node) {
-        const language = node.firstChild.getAttribute('class') || '';
-        const languageMatch = language.match(/language-(\S+)/);
+        const codeElement = node.querySelector('code');
+        const languageClasses = [
+          codeElement?.getAttribute('class') || '',
+          node.getAttribute('class') || ''
+        ].join(' ');
+        const languageMatch = languageClasses.match(/(?:language|lang)-(\S+)/);
         const languageIdentifier = languageMatch ? languageMatch[1] : '';
+        const codeContainer = (codeElement || node).cloneNode(true);
+
+        // Syntax highlighters often emit <pre><span>...<br>...</span></pre>.
+        // textContent preserves the highlighted text, but <br> needs explicit handling.
+        const lineBreaks = codeContainer.querySelectorAll('br');
+        lineBreaks.forEach(lineBreak => lineBreak.replaceWith('\n'));
+
+        const code = codeContainer.textContent.replace(/\n$/, '');
+        const fenceMatches = code.match(/^`{3,}/gm) || [];
+        const fenceSize = fenceMatches.reduce(
+          (size, fence) => Math.max(size, fence.length + 1),
+          3
+        );
+        const fence = '`'.repeat(fenceSize);
+
         return (
-          '\n\n```' + languageIdentifier + '\n' +
-          node.firstChild.textContent.replace(/\n$/, '') +
-          '\n```\n\n'
+          '\n\n' + fence + languageIdentifier + '\n' +
+          code +
+          '\n' + fence + '\n\n'
         );
       }
     });

--- a/testbench.html
+++ b/testbench.html
@@ -12,6 +12,7 @@
         .instructions { background: #fff3e0; padding: 15px; border-radius: 6px; border-left: 4px solid #ff9800; margin-bottom: 20px; }
         .expected { background: #e3f2fd; padding: 10px; border-radius: 4px; margin: 10px 0; font-size: 0.9em; }
         code { background: #263238; color: #aed581; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+        pre code, pre span { background: none; color: inherit; padding: 0; }
         .success { color: #2e7d32; font-weight: bold; }
         .warning { color: #f57c00; font-weight: bold; }
         table { border-collapse: collapse; width: 100%; margin: 15px 0; }
@@ -190,6 +191,28 @@
         </ul>
         <div class="expected"><span class="success">Expected (Include Links ON):</span> Links as <code>[text](url)</code></div>
         <div class="expected"><span class="warning">Expected (Include Links OFF):</span> Only text, no URLs</div>
+    </div>
+
+    <div class="test-section">
+        <h2>Test 10: Preformatted Code Blocks</h2>
+        <p>Standard code block with a language class:</p>
+        <pre><code class="language-javascript">const greeting = "hello";
+console.log(greeting);</code></pre>
+        <p>Syntax-highlighted code block without a code element:</p>
+        <pre><span class="hljs-attr">apiVersion:</span> <span class="hljs-string">admissionregistration.k8s.io/v1</span><br><span class="hljs-attr">kind:</span> <span class="hljs-string">ValidatingAdmissionPolicyBinding</span><br><span class="hljs-attr">metadata:</span><br>  <span class="hljs-attr">name:</span> <span class="hljs-string">replicalimit-binding-test.example.com</span></pre>
+        <p>Shiki-style code block with line spans:</p>
+        <!-- https://zod.dev/api example codeblocks -->
+        <figure class="not-prose group fd-codeblock shiki">
+            <button type="button" aria-label="Copy Text">Copy Text</button>
+            <div>
+                <pre><code><span class="line"><span>import</span><span> *</span><span> as</span><span> z </span><span>from</span><span> "zod"</span><span>;</span></span>
+<span class="line"> </span>
+<span class="line"><span>// primitive types</span></span>
+<span class="line"><span>z.</span><span>string</span><span>();</span></span>
+<span class="line"><span>z.</span><span>number</span><span>();</span></span></code></pre>
+            </div>
+        </figure>
+        <div class="expected"><span class="success">Expected:</span> All three examples should appear as fenced Markdown code blocks, with line breaks and indentation preserved</div>
     </div>
 
 </body>


### PR DESCRIPTION
## Changes Made

Converts every `<pre>` into a fenced code block and treats every `<br>` elements within the block as newline.
Preserves indentation and highlights.
Detects language-* and lang-* classes.
Tried to preserve preexisting code block collision logic.


## Test URLs

https://medium.com/@chetanatole99/a-deep-dive-into-kubernetes-validating-admission-policy-the-native-alternative-to-webhooks-b35df05e6a5b

## Screenshot

Not needed