### PR TITLE
feat: add Jest unit tests and GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run unit tests
+      run: npm test

--- a/README.md
+++ b/README.md
@@ -357,7 +357,33 @@ make help          # Show help message
 
 ## Testing
 
-A test bench page (`testbench.html`) is included to verify extension functionality:
+### Unit Tests
+
+The project uses [Jest](https://jestjs.io/) for unit testing. Tests live in the `tests/` directory, with Chrome extension APIs mocked in `tests/setup.js`.
+
+1. Install dependencies (requires Node.js 20+):
+   ```bash
+   npm install
+   ```
+
+2. Run the test suite:
+   ```bash
+   npm test
+   ```
+
+Jest prints a pass/fail summary per test file; a non-zero exit code means at least one test failed. The suite also runs automatically in CI (GitHub Actions) on every push to `main` and on every pull request — see `.github/workflows/test.yml`.
+
+To add tests for a new module, export it for Node at the bottom of the source file (see `extension/token-counter.js` for the pattern):
+
+```javascript
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = MyModule;
+}
+```
+
+Then create `tests/my-module.test.js` following the structure of `tests/token-counter.test.js`.
+
+A test bench page (`testbench.html`) is included to verify extension functionality manually:
 
 ### Running the Test Bench
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/tests/setup.js'],
+  testMatch: ['<rootDir>/tests/**/*.test.js']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "llmfeeder",
+  "version": "2.1.0",
+  "description": "Web to Markdown converter for ChatGPT, Claude & AI. Extract clean content, copy to clipboard.",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,20 @@
+// Shared test environment setup
+// jsdom does not provide TextEncoder/TextDecoder, so pull them from Node
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+  global.TextDecoder = TextDecoder;
+}
+
+// Minimal mock of the Chrome extension APIs used by the codebase.
+// Tests can override individual methods with jest.spyOn() as needed.
+global.chrome = {
+  storage: {
+    local: {
+      get: async () => ({}),
+      set: async () => {},
+      remove: async () => {}
+    }
+  }
+};

--- a/tests/token-counter.test.js
+++ b/tests/token-counter.test.js
@@ -1,0 +1,200 @@
+// Unit tests for extension/token-counter.js
+//
+// TokenCounter is an IIFE singleton with internal caches, so each test
+// gets a fresh copy via jest.resetModules(). Chrome storage APIs come
+// from the mock in tests/setup.js; fetch is mocked per test.
+
+describe('TokenCounter', () => {
+  let TokenCounter;
+
+  // Encoding with no BPE merges: every byte counts as one token
+  const emptyEncoding = { bpe_ranks: {} };
+
+  function mockFetchWith(encodingData) {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => encodingData
+    });
+  }
+
+  function mockFetchFailure() {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    TokenCounter = require('../extension/token-counter.js');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  describe('count()', () => {
+    it('counts one token per byte when the encoding has no BPE merges', async () => {
+      mockFetchWith(emptyEncoding);
+
+      const count = await TokenCounter.count('hi');
+
+      expect(count).toBe(2);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://tiktoken.pages.dev/js/cl100k_base.json'
+      );
+    });
+
+    it('merges bytes into a single token when a BPE rank matches', async () => {
+      // "hi" is bytes [104, 105]; rank the pair so it merges to one token
+      mockFetchWith({ bpe_ranks: { '104,105': 1 } });
+
+      const count = await TokenCounter.count('hi');
+
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 for empty or non-string input', async () => {
+      mockFetchWith(emptyEncoding);
+
+      expect(await TokenCounter.count('')).toBe(0);
+      expect(await TokenCounter.count(null)).toBe(0);
+      expect(await TokenCounter.count(undefined)).toBe(0);
+    });
+
+    it('falls back to heuristic counting when the encoding cannot be loaded', async () => {
+      mockFetchFailure();
+
+      // Heuristic: "hi" is one word of 2 bytes -> 1 token, +1 special token
+      const count = await TokenCounter.count('hi');
+
+      expect(count).toBe(2);
+    });
+
+    it('uses the encoding cached in chrome.storage without fetching', async () => {
+      global.fetch = jest.fn();
+      jest.spyOn(chrome.storage.local, 'get').mockResolvedValue({
+        llmfeeder_encoding_cache: {
+          version: '1',
+          cl100k_base: emptyEncoding
+        }
+      });
+
+      const count = await TokenCounter.count('hi');
+
+      expect(count).toBe(2);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('saves a freshly fetched encoding to chrome.storage', async () => {
+      mockFetchWith(emptyEncoding);
+      const setSpy = jest.spyOn(chrome.storage.local, 'set');
+
+      await TokenCounter.count('hi');
+
+      expect(setSpy).toHaveBeenCalledWith({
+        llmfeeder_encoding_cache: expect.objectContaining({
+          version: '1',
+          cl100k_base: emptyEncoding
+        })
+      });
+    });
+
+    it('fetches the encoding only once for repeated calls', async () => {
+      mockFetchWith(emptyEncoding);
+
+      await TokenCounter.count('first');
+      await TokenCounter.count('second');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('countSync()', () => {
+    it('uses the heuristic when no encoding is cached', () => {
+      expect(TokenCounter.countSync('hi')).toBe(2);
+      expect(TokenCounter.countSync('')).toBe(0);
+    });
+
+    it('uses the cached encoding after count() has loaded it', async () => {
+      mockFetchWith(emptyEncoding);
+      await TokenCounter.count('warm up');
+
+      expect(TokenCounter.countSync('hi')).toBe(2);
+    });
+  });
+
+  describe('countWithLimit()', () => {
+    it('reports usage against the limit', async () => {
+      mockFetchWith(emptyEncoding);
+
+      // "hi" counts as 2 tokens against a limit of 4
+      const result = await TokenCounter.countWithLimit('hi', 4);
+
+      expect(result).toEqual({
+        count: 2,
+        limit: 4,
+        percentage: 50,
+        isOverLimit: false,
+        remaining: 2
+      });
+    });
+
+    it('flags text that exceeds the limit', async () => {
+      mockFetchWith(emptyEncoding);
+
+      const result = await TokenCounter.countWithLimit('hello', 3);
+
+      expect(result.isOverLimit).toBe(true);
+      expect(result.remaining).toBe(0);
+    });
+  });
+
+  describe('format()', () => {
+    it('formats a plain count', () => {
+      expect(TokenCounter.format(500)).toBe('500 tokens');
+    });
+
+    it('formats a count with a limit and percentage', () => {
+      expect(TokenCounter.format(50, 100)).toBe('50 / 100 tokens (50%)');
+    });
+  });
+
+  describe('init() and cache management', () => {
+    it('init() resolves true when the encoding loads', async () => {
+      mockFetchWith(emptyEncoding);
+
+      await expect(TokenCounter.init()).resolves.toBe(true);
+    });
+
+    it('init() resolves false when the encoding cannot be loaded', async () => {
+      mockFetchFailure();
+
+      await expect(TokenCounter.init()).resolves.toBe(false);
+    });
+
+    it('getStatus() reflects whether an encoding is cached', async () => {
+      expect(TokenCounter.getStatus()).toEqual({
+        isReady: false,
+        cachedEncodings: [],
+        defaultEncoding: 'cl100k_base'
+      });
+
+      mockFetchWith(emptyEncoding);
+      await TokenCounter.init();
+
+      const status = TokenCounter.getStatus();
+      expect(status.isReady).toBe(true);
+      expect(status.cachedEncodings).toContain('cl100k_base');
+    });
+
+    it('clearCache() empties the cache and clears chrome.storage', async () => {
+      mockFetchWith(emptyEncoding);
+      await TokenCounter.init();
+      const removeSpy = jest.spyOn(chrome.storage.local, 'remove');
+
+      await TokenCounter.clearCache();
+
+      expect(TokenCounter.getStatus().isReady).toBe(false);
+      expect(removeSpy).toHaveBeenCalledWith('llmfeeder_encoding_cache');
+    });
+  });
+});


### PR DESCRIPTION
Resolves #44

## Summary

- **Jest test setup** with `jsdom` environment (`package.json`, `jest.config.js`)
- **Chrome extension API mocks** in `tests/setup.js` — a minimal `chrome.storage.local` mock that tests can override with `jest.spyOn()`, plus `TextEncoder`/`TextDecoder` polyfills for jsdom
- **17 unit tests for the `TokenCounter` module** (`tests/token-counter.test.js`) as a template for future contributors, covering:
  - token counting with and without BPE merges
  - encoding caching via `chrome.storage` (cache hit, cache write, single fetch)
  - fallback heuristic counting when the CDN is unreachable
  - `countWithLimit()` limit/percentage reporting
  - `format()`, `init()`, `getStatus()`, `clearCache()`
- **CI workflow** (`.github/workflows/test.yml`) running the suite on every push to `main` and on every pull request, mirroring the structure of the existing `pr-validation.yml`
- **README documentation** on running tests locally, interpreting results, and adding tests for new modules

## Notes

- `TokenCounter` was chosen as the example module because it already exposes a CommonJS export guard and exercises the Chrome storage APIs, making it a good template for mocking patterns.
- `npm install` is used in CI (rather than `npm ci`) because the repo's `.gitignore` intentionally excludes lockfiles.
- The build pipeline is unaffected: `scripts/build.sh` copies an explicit file list, so `package.json`, `tests/`, and `node_modules/` never enter the extension packages.

## Test plan

- [x] `npm test` passes locally (17/17 tests, Node 26)
- [x] Verified `build.sh` source packaging is unaffected by the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)