### PR TITLE
Fix #91: lazy-loading auto-scroll + shared time budget

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -336,6 +336,7 @@
    */
   const KNOWN_LAZY_HOSTS = [
     'gemini.google.com',
+    'aistudio.google.com',
     'chat.openai.com',
     'chatgpt.com',
     'claude.ai',
@@ -449,19 +450,35 @@
   /**
    * Find all scrollable containers on the page using the same
    * `isMeaningfullyScrollable` heuristic as the detector.
+   *
+   * Semantic lazy-load containers (role=log/feed, data-conversation, etc.)
+   * take priority. Burning budget on the window / generic main wrappers as
+   * well would leave less time for the surface that actually loads content —
+   * the multi-scroller timeout #101 fixed. Only fall back to those generic
+   * containers when no semantic match is scrollable.
    */
   function findScrollableContainers() {
     const containers = [];
+    const seen = new Set();
+
+    document.querySelectorAll(LAZY_CONTAINER_SELECTORS.join(', ')).forEach(el => {
+      if (isMeaningfullyScrollable(el) && !seen.has(el)) {
+        seen.add(el);
+        containers.push({ element: el, isWindow: false });
+      }
+    });
+
+    if (containers.length > 0) {
+      return containers;
+    }
 
     if (document.documentElement.scrollHeight > window.innerHeight * 1.5) {
       containers.push({ element: document.documentElement, isWindow: true });
     }
 
-    const candidates = document.querySelectorAll(LAZY_CONTAINER_SELECTORS.join(', ') +
-      ', main, article, .main-content, #content');
-
-    candidates.forEach(el => {
-      if (isMeaningfullyScrollable(el)) {
+    document.querySelectorAll('main, article, .main-content, #content').forEach(el => {
+      if (isMeaningfullyScrollable(el) && !seen.has(el)) {
+        seen.add(el);
         containers.push({ element: el, isWindow: false });
       }
     });
@@ -574,7 +591,8 @@
       preserveTables: settings.preserveTables,
       includeImages: settings.includeImages,
       includeTitle: settings.includeTitle,
-      includeLinks: settings.includeLinks
+      includeLinks: settings.includeLinks,
+      triggerLazyLoading: settings.triggerLazyLoading === true
     });
 
     // Detect and handle lazy-loaded content before extraction.

--- a/extension/content.js
+++ b/extension/content.js
@@ -15,11 +15,14 @@
     GENERAL: 'An error occurred during conversion.'
   };
 
-  const CONVERSION_TIMEOUT = 15000; // 15 seconds (increased for iframe handling)
+  const CONVERSION_TIMEOUT = 15000; // 15 seconds baseline (extended dynamically when scrolling lazy-loaded pages)
   const IFRAME_EXTRACTION_TIMEOUT = 1000; // 1 second per iframe
   const MIN_CONTENT_LENGTH = 50; // Minimum meaningful content length
   const MAX_IFRAME_BATCH_SIZE = 5; // Process up to 5 iframes in parallel
   const MAX_DEBUG_LOG_ENTRIES = 500; // Keep memory usage in check
+  const SCROLL_LOAD_DELAY = 300; // ms to wait after scroll for content to load
+  const MAX_SCROLL_ATTEMPTS = 50; // Maximum scroll iterations to prevent infinite loops
+  const SCROLL_TIMEOUT_HEADROOM = MAX_SCROLL_ATTEMPTS * SCROLL_LOAD_DELAY; // ms of extra time we may need when scrolling
 
   // Message action constants for security validation
   const MESSAGE_ACTIONS = {
@@ -166,12 +169,19 @@
 
     // Main conversion handler - async
     if (request.action === 'convertToMarkdown') {
+      // Extend the conversion timeout when the user has opted into the
+      // scroll-to-load pass, since that step alone can take up to
+      // SCROLL_TIMEOUT_HEADROOM ms before extraction even begins.
+      const requestSettings = request.settings || request.options || {};
+      const conversionTimeout = requestSettings.triggerLazyLoading === true
+        ? CONVERSION_TIMEOUT + SCROLL_TIMEOUT_HEADROOM
+        : CONVERSION_TIMEOUT;
       const timeoutId = setTimeout(() => {
         sendResponse({
           success: false,
           error: ERROR_MESSAGES.TIMEOUT
         });
-      }, CONVERSION_TIMEOUT);
+      }, conversionTimeout);
 
       (async () => {
         try {
@@ -310,6 +320,218 @@
   }
 
   // ==========================================================================
+  // LAZY LOADING DETECTION AND SCROLL EXTRACTION
+  // ==========================================================================
+
+  /**
+   * Hosts that we know ship lazy-loaded conversational UIs. Exact/subdomain
+   * matching keeps the detector focused without treating unrelated domains
+   * like `notchatgpt.com` as positive matches.
+   */
+  const KNOWN_LAZY_HOSTS = [
+    'gemini.google.com',
+    'chat.openai.com',
+    'chatgpt.com',
+    'claude.ai',
+    'poe.com',
+    'perplexity.ai',
+    'copilot.microsoft.com'
+  ];
+
+  /**
+   * Tight, semantically-meaningful selectors. We deliberately avoid loose
+   * `[class*="..."]` matches here because they fire on too many ordinary
+   * pages (any class containing "chat", "scroll", "conversation", etc.) and
+   * trigger a noisy scroll pass + footer warning when nothing is actually
+   * lazy-loaded.
+   */
+  const LAZY_CONTAINER_SELECTORS = [
+    '[role="log"]',
+    '[role="feed"]',
+    '[data-conversation]',
+    '[data-virtual]',
+    '[data-test-id*="conversation"]'
+  ];
+
+  /**
+   * Single source of truth for "is this DOM node a scrollable container we
+   * could meaningfully scroll through?". Used by both the detector and the
+   * scroll-pass collector so the threshold lives in one place.
+   */
+  function isMeaningfullyScrollable(el) {
+    const style = window.getComputedStyle(el);
+    const overflowsY = style.overflowY === 'auto' || style.overflowY === 'scroll';
+    return overflowsY && el.clientHeight > 0 && el.scrollHeight > el.clientHeight * 2;
+  }
+
+  /**
+   * Detects if a page likely uses virtual scrolling/lazy loading for content.
+   * Cheap and short-circuits on the first positive signal so we don't pay
+   * an O(DOM) scan on every conversion.
+   */
+  function detectLazyLoadingPattern() {
+    const host = window.location.hostname || '';
+    const matchedHost = KNOWN_LAZY_HOSTS.find(h => host === h || host.endsWith('.' + h)) || null;
+    if (matchedHost) {
+      DebugLog.log('Lazy loading detection', { matchedHost, isLazyLoaded: true });
+      return { isLazyLoaded: true, reason: 'host:' + matchedHost };
+    }
+
+    if (document.querySelector(LAZY_CONTAINER_SELECTORS.join(', '))) {
+      DebugLog.log('Lazy loading detection', { reason: 'semantic-selector', isLazyLoaded: true });
+      return { isLazyLoaded: true, reason: 'semantic' };
+    }
+
+    DebugLog.log('Lazy loading detection', { isLazyLoaded: false });
+    return { isLazyLoaded: false, reason: null };
+  }
+
+  /**
+   * Attempts to load all lazy-loaded content by scrolling through the page.
+   * Returns information about what was loaded; `scrolled: false` means no
+   * suitable container was found and the caller should not warn the user
+   * about partial content.
+   */
+  async function scrollToLoadAllContent(scrollables) {
+    if (scrollables.length === 0) {
+      DebugLog.log('No scrollable containers found');
+      return { scrolled: false, heightDelta: 0, contentChanged: false };
+    }
+
+    DebugLog.log('Found scrollable containers', { count: scrollables.length });
+
+    // Save the user's viewport position so we can restore it after the
+    // scroll-pass instead of dumping them at the top of the page.
+    const savedScrollX = window.scrollX;
+    const savedScrollY = window.scrollY;
+
+    let totalHeightDelta = 0;
+    let contentChanged = false;
+    for (const container of scrollables) {
+      const result = await scrollContainerToLoadContent(container);
+      totalHeightDelta += result.heightDelta;
+      contentChanged = contentChanged || result.contentChanged;
+    }
+
+    window.scrollTo(savedScrollX, savedScrollY);
+
+    DebugLog.log('Scroll loading complete', { totalHeightDelta, contentChanged });
+    return { scrolled: true, heightDelta: totalHeightDelta, contentChanged };
+  }
+
+  /**
+   * Find all scrollable containers on the page using the same
+   * `isMeaningfullyScrollable` heuristic as the detector.
+   */
+  function findScrollableContainers() {
+    const containers = [];
+
+    if (document.documentElement.scrollHeight > window.innerHeight * 1.5) {
+      containers.push({ element: document.documentElement, isWindow: true });
+    }
+
+    const candidates = document.querySelectorAll(LAZY_CONTAINER_SELECTORS.join(', ') +
+      ', main, article, .main-content, #content');
+
+    candidates.forEach(el => {
+      if (isMeaningfullyScrollable(el)) {
+        containers.push({ element: el, isWindow: false });
+      }
+    });
+
+    return containers;
+  }
+
+  /**
+   * Scroll a container to load lazy-loaded content.
+   * Stall detection looks at `scrollHeight` and a bounded text signature
+   * because virtualised lists can recycle DOM nodes without growing height.
+   */
+  async function scrollContainerToLoadContent(containerInfo) {
+    const { element, isWindow } = containerInfo;
+    const getScrollHeight = () => isWindow ? document.documentElement.scrollHeight : element.scrollHeight;
+    const getClientHeight = () => isWindow ? window.innerHeight : element.clientHeight;
+    const getTextSignature = () => {
+      const text = ((isWindow ? document.body : element).innerText || '').trim();
+      return text.slice(0, 2000) + '|' + text.slice(-2000);
+    };
+    const getCurrentScroll = () => isWindow ? window.scrollY : element.scrollTop;
+    const scrollTo = (pos) => {
+      if (isWindow) {
+        window.scrollTo(0, pos);
+      } else {
+        element.scrollTop = pos;
+      }
+    };
+
+    const originalScroll = getCurrentScroll();
+    const startHeight = getScrollHeight();
+    const startTextSignature = getTextSignature();
+    let previousHeight = startHeight;
+    let previousTextSignature = startTextSignature;
+    let attempts = 0;
+    let stallCount = 0;
+
+    // First, scroll to top to ensure top content is loaded
+    scrollTo(0);
+    await sleep(SCROLL_LOAD_DELAY);
+
+    const clientHeight = getClientHeight();
+    const scrollStep = clientHeight * 0.8;
+    let currentPos = 0;
+
+    while (attempts < MAX_SCROLL_ATTEMPTS) {
+      attempts++;
+
+      currentPos += scrollStep;
+      scrollTo(currentPos);
+      await sleep(SCROLL_LOAD_DELAY);
+
+      const newHeight = getScrollHeight();
+      const newTextSignature = getTextSignature();
+
+      const grewHeight = newHeight > previousHeight;
+      const changedText = newTextSignature !== previousTextSignature;
+
+      if (grewHeight || changedText) {
+        previousHeight = newHeight;
+        previousTextSignature = newTextSignature;
+        stallCount = 0;
+      } else {
+        stallCount++;
+      }
+
+      const maxScroll = newHeight - clientHeight;
+      if (currentPos >= maxScroll - 10) {
+        if (stallCount >= 3) {
+          DebugLog.log('Reached bottom of scrollable container', {
+            attempts,
+            finalHeight: newHeight,
+            heightDelta: newHeight - startHeight,
+            contentChanged: newTextSignature !== startTextSignature
+          });
+          break;
+        }
+        // Nudge past the bottom to trigger any remaining lazy loaders.
+        currentPos = maxScroll + 100;
+        scrollTo(currentPos);
+        await sleep(SCROLL_LOAD_DELAY);
+      }
+    }
+
+    scrollTo(originalScroll);
+
+    return {
+      heightDelta: previousHeight - startHeight,
+      contentChanged: previousTextSignature !== startTextSignature
+    };
+  }
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  // ==========================================================================
   // MAIN CONVERSION FUNCTION
   // ==========================================================================
 
@@ -322,6 +544,36 @@
       includeTitle: settings.includeTitle,
       includeLinks: settings.includeLinks
     });
+
+    // Detect and handle lazy-loaded content before extraction.
+    // The detector itself is gated on the user setting so we don't pay for
+    // host/selector lookups (or surface a false-positive footer warning) on
+    // pages where the user has explicitly opted out. We also skip the
+    // scroll-pass when the user is converting a selection: scrolling moves
+    // the page out from under them and `window.getSelection()` would be
+    // collapsed by the time we read it.
+    let lazyLoadInfo = { isLazyLoaded: false, reason: null };
+    let scrollResult = { scrolled: false, heightDelta: 0, contentChanged: false };
+    const lazyLoadingEnabled = settings.triggerLazyLoading === true &&
+                               settings.contentScope !== 'selection';
+
+    if (lazyLoadingEnabled) {
+      lazyLoadInfo = detectLazyLoadingPattern();
+      if (lazyLoadInfo.isLazyLoaded) {
+        // Probe for actual containers before notifying the user. If there's
+        // nothing meaningful to scroll we'd rather stay silent than flash a
+        // toast that doesn't reflect any real work.
+        const probe = findScrollableContainers();
+        if (probe.length > 0) {
+          DebugLog.log('Attempting to load lazy-loaded content via scrolling', { reason: lazyLoadInfo.reason });
+          showNotification('Loading content...', 'Scrolling to load all content before extraction');
+          scrollResult = await scrollToLoadAllContent(probe);
+          DebugLog.log('Scroll loading result', scrollResult);
+        } else {
+          DebugLog.log('Lazy load detected but no scrollable container; skipping scroll-pass');
+        }
+      }
+    }
 
     const docClone = document.cloneNode(true);
     let content;
@@ -393,6 +645,16 @@
         const warningText = `\n\n---\n> **Note:** This page contains ${iframeWarning.count} cross-origin iframe(s) that could not be accessed due to browser security policies. Some content may be missing. Links to these iframes have been preserved where possible.\n`;
         markdown += warningText;
         DebugLog.log('Added iframe warning', { count: iframeWarning.count });
+      }
+
+      // Only warn when we have evidence the scroll-pass changed the rendered
+      // content. Emitting this for every positive detector hit is noisier
+      // than helpful on pages that use ARIA logs for non-lazy content.
+      if (lazyLoadInfo.isLazyLoaded && scrollResult.scrolled &&
+          (scrollResult.heightDelta > 0 || scrollResult.contentChanged)) {
+        const lazyLoadWarning = `\n\n---\n> **Note:** This page uses dynamic content loading (virtual scrolling). The extension scrolled to load all visible content, but some may still be missing if it wasn't rendered in the DOM. For long conversations or feeds, try scrolling through the entire content manually before converting.\n`;
+        markdown += lazyLoadWarning;
+        DebugLog.log('Added lazy load warning', { scrollResult, reason: lazyLoadInfo.reason });
       }
 
       return postProcessMarkdown(markdown, settings, articleData);

--- a/extension/content.js
+++ b/extension/content.js
@@ -21,8 +21,14 @@
   const MAX_IFRAME_BATCH_SIZE = 5; // Process up to 5 iframes in parallel
   const MAX_DEBUG_LOG_ENTRIES = 500; // Keep memory usage in check
   const SCROLL_LOAD_DELAY = 300; // ms to wait after scroll for content to load
-  const MAX_SCROLL_ATTEMPTS = 50; // Maximum scroll iterations to prevent infinite loops
-  const SCROLL_TIMEOUT_HEADROOM = MAX_SCROLL_ATTEMPTS * SCROLL_LOAD_DELAY; // ms of extra time we may need when scrolling
+  const MAX_SCROLL_ATTEMPTS = 50; // Maximum scroll iterations per container
+  // Wall-clock ceiling for the whole scroll pass, shared across every container
+  // we walk. MAX_SCROLL_ATTEMPTS alone cannot bound the pass: a page with N
+  // scrollable containers costs N times the per-container budget, which would
+  // outlive the conversion timeout and keep yanking the page around long after
+  // the user has been shown an error.
+  const SCROLL_PASS_BUDGET = 15000;
+  const SCROLL_TIMEOUT_HEADROOM = SCROLL_PASS_BUDGET; // ms of extra time we may need when scrolling
 
   // Message action constants for security validation
   const MESSAGE_ACTIONS = {
@@ -405,17 +411,38 @@
     const savedScrollX = window.scrollX;
     const savedScrollY = window.scrollY;
 
+    // Share one wall-clock budget across every container. Each container gets
+    // an even slice of whatever time is left, so a container that finishes
+    // early hands its unused time to the ones after it.
+    const passDeadline = Date.now() + SCROLL_PASS_BUDGET;
+
     let totalHeightDelta = 0;
     let contentChanged = false;
-    for (const container of scrollables) {
-      const result = await scrollContainerToLoadContent(container);
+    let containersScrolled = 0;
+    for (let i = 0; i < scrollables.length; i++) {
+      const timeLeft = passDeadline - Date.now();
+      if (timeLeft <= SCROLL_LOAD_DELAY) {
+        DebugLog.log('Scroll budget exhausted, skipping remaining containers', {
+          skipped: scrollables.length - i
+        });
+        break;
+      }
+
+      const containerDeadline = Date.now() + timeLeft / (scrollables.length - i);
+      const result = await scrollContainerToLoadContent(scrollables[i], containerDeadline);
       totalHeightDelta += result.heightDelta;
       contentChanged = contentChanged || result.contentChanged;
+      containersScrolled++;
     }
 
     window.scrollTo(savedScrollX, savedScrollY);
 
-    DebugLog.log('Scroll loading complete', { totalHeightDelta, contentChanged });
+    // Virtualised lists re-render from their scroll handler, which fires
+    // asynchronously. Without this settle delay we clone the DOM mid-render
+    // and capture fewer rows than were on screen before the pass started.
+    await sleep(SCROLL_LOAD_DELAY);
+
+    DebugLog.log('Scroll loading complete', { totalHeightDelta, contentChanged, containersScrolled });
     return { scrolled: true, heightDelta: totalHeightDelta, contentChanged };
   }
 
@@ -447,7 +474,7 @@
    * Stall detection looks at `scrollHeight` and a bounded text signature
    * because virtualised lists can recycle DOM nodes without growing height.
    */
-  async function scrollContainerToLoadContent(containerInfo) {
+  async function scrollContainerToLoadContent(containerInfo, deadline) {
     const { element, isWindow } = containerInfo;
     const getScrollHeight = () => isWindow ? document.documentElement.scrollHeight : element.scrollHeight;
     const getClientHeight = () => isWindow ? window.innerHeight : element.clientHeight;
@@ -474,13 +501,15 @@
 
     // First, scroll to top to ensure top content is loaded
     scrollTo(0);
-    await sleep(SCROLL_LOAD_DELAY);
+    if (Date.now() + SCROLL_LOAD_DELAY <= deadline) {
+      await sleep(SCROLL_LOAD_DELAY);
+    }
 
     const clientHeight = getClientHeight();
     const scrollStep = clientHeight * 0.8;
     let currentPos = 0;
 
-    while (attempts < MAX_SCROLL_ATTEMPTS) {
+    while (attempts < MAX_SCROLL_ATTEMPTS && Date.now() + SCROLL_LOAD_DELAY <= deadline) {
       attempts++;
 
       currentPos += scrollStep;
@@ -515,6 +544,9 @@
         // Nudge past the bottom to trigger any remaining lazy loaders.
         currentPos = maxScroll + 100;
         scrollTo(currentPos);
+        if (Date.now() + SCROLL_LOAD_DELAY > deadline) {
+          break;
+        }
         await sleep(SCROLL_LOAD_DELAY);
       }
     }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -344,6 +344,17 @@ Source: [{title}]({url})</textarea>
               <small style="display: block; margin-top: 4px; color: var(--text-secondary); text-align: center;">Logs are rewritten on each conversion</small>
             </div>
 
+            <div class="setting-group">
+              <h3>Lazy Loading Support</h3>
+              <label class="setting-option">
+                <input type="checkbox" id="triggerLazyLoading" />
+                <span>Auto-scroll to load more content</span>
+              </label>
+              <small style="display: block; margin-top: 4px; color: var(--text-secondary);">
+                For pages with virtual scrolling (e.g., Gemini, ChatGPT), attempts to load more content before extraction. Off by default; turn on for chat interfaces.
+              </small>
+            </div>
+
             <div class="setting-group rating-cta" id="ratingCta">
               <button class="rating-dismiss" id="dismissRatingCta" title="Dismiss">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="rating-dismiss-icon">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -719,8 +719,11 @@ function getCurrentSettings() {
     preserveTables: preserveTablesCheckbox.checked,
     includeImages: includeImagesCheckbox.checked,
     includeTitle: includeTitleCheckbox.checked,
+    includeLinks: includeLinksCheckbox.checked,
     includeMetadata: includeMetadataCheckbox.checked,
     metadataFormat: metadataFormatTextarea.value,
+    debugMode: debugModeCheckbox.checked,
+    triggerLazyLoading: triggerLazyLoadingCheckbox.checked,
   };
 }
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -137,6 +137,7 @@ const metadataFormatContainer = document.getElementById("metadataFormatContainer
 const resetMetadataFormatBtn = document.getElementById("resetMetadataFormat");
 const debugModeCheckbox = document.getElementById("debugMode");
 const copyLogsBtn = document.getElementById("copyLogsBtn");
+const triggerLazyLoadingCheckbox = document.getElementById("triggerLazyLoading");
 
 // Token Counter DOM elements
 const tokenCounter = document.getElementById("tokenCounter");
@@ -365,6 +366,7 @@ async function loadSettings() {
     includeMetadataCheckbox.checked = data.includeMetadata;
     metadataFormatTextarea.value = data.metadataFormat;
     debugModeCheckbox.checked = data.debugMode;
+    triggerLazyLoadingCheckbox.checked = data.triggerLazyLoading === true;
     showTokenCountCheckbox.checked = tokenSettings.showTokenCount;
     tokenContextLimitSelect.value = tokenSettings.tokenContextLimit.toString();
 
@@ -391,6 +393,7 @@ async function saveSettings() {
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
+    const triggerLazyLoading = triggerLazyLoadingCheckbox.checked;
     const showTokenCount = showTokenCountCheckbox.checked;
     const tokenContextLimit = parseInt(tokenContextLimitSelect.value, 10);
 
@@ -403,6 +406,7 @@ async function saveSettings() {
       includeMetadata,
       metadataFormat,
       debugMode,
+      triggerLazyLoading,
       showTokenCount,
       tokenContextLimit,
     });
@@ -835,6 +839,7 @@ async function convertToMarkdown(scopeOverride) {
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
+    const triggerLazyLoading = triggerLazyLoadingCheckbox.checked;
 
     // Send message to content script
     const response = await browserAPI.tabs.sendMessage(tabs[0].id, {
@@ -848,6 +853,7 @@ async function convertToMarkdown(scopeOverride) {
         includeMetadata,
         metadataFormat,
         debugMode,
+        triggerLazyLoading,
       },
     });
 
@@ -919,6 +925,7 @@ async function downloadMarkdown() {
     const includeMetadata = includeMetadataCheckbox.checked;
     const metadataFormat = metadataFormatTextarea.value;
     const debugMode = debugModeCheckbox.checked;
+    const triggerLazyLoading = triggerLazyLoadingCheckbox.checked;
 
     // Send message to content script
     const response = await browserAPI.tabs.sendMessage(tabs[0].id, {
@@ -932,6 +939,7 @@ async function downloadMarkdown() {
         includeMetadata,
         metadataFormat,
         debugMode,
+        triggerLazyLoading,
       },
     });
 
@@ -1105,6 +1113,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateDebugModeVisibility();
     saveSettings();
   });
+  triggerLazyLoadingCheckbox.addEventListener("change", saveSettings);
 
   // Metadata format settings
   includeMetadataCheckbox.addEventListener("change", () => {

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -15,7 +15,11 @@ const SettingsUtils = (function() {
       includeLinks: true,
       includeMetadata: true,
       metadataFormat: DEFAULT_METADATA_FORMAT,
-      debugMode: false
+      debugMode: false,
+      // Off by default. Triggers a scroll-pass on lazy-loading surfaces (chat
+      // UIs, virtualised feeds) before extraction. Has visible side effects
+      // (page movement, optional footer warning) so users opt in explicitly.
+      triggerLazyLoading: false
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #91. Combines the work from #93 and #101 into one clean PR rebased on current `main`.

Some chat/AI pages only render older messages after scroll, so conversion can miss content. This adds an **opt-in** lazy-loading scroll pass, plus the time-budget fix so multi-container pages cannot hang past the conversion timeout.

## What happened to #93 / #101

- **#101** was stacked on #93 and got auto-merged into the `#93` branch (not into `main`) when both heads were aligned during review.
- **#93** is still open against `main` but is behind (`#99`, `#100`). This PR supersedes it with the same feature set, rebased onto latest `main`.

Prefer merging **this PR**; #93 can be closed as superseded.

## Changes

- Opt-in setting: **Auto-scroll to load more content** (`triggerLazyLoading`, default off)
- Detect known AI/chat hosts + semantic containers (`[role="log"]`, `[role="feed"]`, etc.)
- Scroll pass with stall detection, scroll restore, and footer warning only when content changed
- Shared `SCROLL_PASS_BUDGET` (15s) across all containers (#101) — prevents timeout + zombie scrolling
- Prefer semantic containers over window/`main` wrappers so budget is spent where content loads
- Known host: `aistudio.google.com`
- Multi-tab `getCurrentSettings()` includes `triggerLazyLoading`

## E2E proof (PASS)

Playwright + unpacked Chromium build:

| Case | Result | Timing |
|------|--------|--------|
| Infinite-scroll off | 10 messages | 9ms |
| Infinite-scroll on | **100 messages** + warning | 13.8s |
| Semantic multi-scroller | success, no timeout | 4.5s |
| Generic multi-scroller (budget) | success, no timeout | **15.0s** |
| Virtualized list | success (recycling limit) | 5.1s |
| Static article | marker OK, no false warning | 6ms |
| Scroll position restored | all cases | — |

![Infinite scroll E2E](https://cursor.com/artifacts/c/art-2ffbbc6a-0893-4037-9b80-fd604f2d3743)
![Budget multi-scroller E2E](https://cursor.com/artifacts/c/art-d0abe0c2-4d74-4452-938d-c39f883a3c69)
![Static article E2E](https://cursor.com/artifacts/c/art-74fafcd1-7ed3-44e8-ae70-90009a81b70b)
![Virtualized list E2E](https://cursor.com/artifacts/c/art-4a4c6352-6406-4a1c-8246-b799628243e0)

## Test plan

- [x] `bash scripts/build.sh all` + manifest JSON validation
- [x] Playwright E2E harness (infinite scroll, multi-scroller budget, static, virtualized)
- [ ] Manual smoke: enable setting on a chat UI, Convert & Copy, confirm more history captured
- [ ] Confirm setting off leaves normal pages unchanged

## Known limitation

DOM-recycling virtualization still cannot retain messages that disappear from the DOM after scroll. Append-style infinite scroll is fully covered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc119e74-ac6a-4ece-a1a1-d65d16e9cebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc119e74-ac6a-4ece-a1a1-d65d16e9cebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

