### PR TITLE
Harden iframe extraction to same-origin DOM access

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -16,9 +16,7 @@
   };
 
   const CONVERSION_TIMEOUT = 15000; // 15 seconds baseline (extended dynamically when scrolling lazy-loaded pages)
-  const IFRAME_EXTRACTION_TIMEOUT = 1000; // 1 second per iframe
   const MIN_CONTENT_LENGTH = 50; // Minimum meaningful content length
-  const MAX_IFRAME_BATCH_SIZE = 5; // Process up to 5 iframes in parallel
   const MAX_DEBUG_LOG_ENTRIES = 500; // Keep memory usage in check
   const SCROLL_LOAD_DELAY = 300; // ms to wait after scroll for content to load
   const MAX_SCROLL_ATTEMPTS = 50; // Maximum scroll iterations per container
@@ -29,12 +27,6 @@
   // the user has been shown an error.
   const SCROLL_PASS_BUDGET = 15000;
   const SCROLL_TIMEOUT_HEADROOM = SCROLL_PASS_BUDGET; // ms of extra time we may need when scrolling
-
-  // Message action constants for security validation
-  const MESSAGE_ACTIONS = {
-    EXTRACT_CONTENT: 'llmfeeder_extract_content',
-    EXTRACT_RESPONSE: 'llmfeeder_extract_content_response'
-  };
 
   // ==========================================================================
   // DEBUG LOGGING SYSTEM
@@ -105,45 +97,6 @@
       onMessage: { addListener: function() {} }
     };
   })();
-
-  // ==========================================================================
-  // CROSS-ORIGIN IFRAME MESSAGE LISTENER
-  // ==========================================================================
-
-  // Listen for messages from parent window for iframe content extraction
-  window.addEventListener('message', (event) => {
-    if (event.data && event.data.action === MESSAGE_ACTIONS.EXTRACT_CONTENT) {
-      try {
-        const content = document.body.cloneNode(true);
-        const elementsToRemove = content.querySelectorAll('script, style, noscript, iframe');
-        for (let i = elementsToRemove.length - 1; i >= 0; i--) {
-          if (elementsToRemove[i].parentNode) {
-            elementsToRemove[i].parentNode.removeChild(elementsToRemove[i]);
-          }
-        }
-        const contentText = content.textContent || '';
-        if (contentText.trim().length > MIN_CONTENT_LENGTH) {
-          event.source.postMessage({
-            action: MESSAGE_ACTIONS.EXTRACT_RESPONSE,
-            messageId: event.data.messageId,
-            content: content.innerHTML
-          }, event.origin);
-        } else {
-          event.source.postMessage({
-            action: MESSAGE_ACTIONS.EXTRACT_RESPONSE,
-            messageId: event.data.messageId,
-            content: null
-          }, event.origin);
-        }
-      } catch (e) {
-        event.source.postMessage({
-          action: MESSAGE_ACTIONS.EXTRACT_RESPONSE,
-          messageId: event.data.messageId,
-          content: null
-        }, event.origin);
-      }
-    }
-  });
 
   // ==========================================================================
   // MESSAGE HANDLERS
@@ -866,6 +819,45 @@
   // IFRAME CONTENT EXTRACTION
   // ==========================================================================
 
+  // Same-origin frames (including srcdoc) are read through the DOM.
+  // Cross-origin frames stay behind the browser's origin checks: we keep a
+  // link/warning instead of asking another window to echo its HTML.
+
+  function isHttpOrHttpsUrl(src) {
+    try {
+      const url = new URL(src, document.baseURI);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function iframeFallbackInfo(iframe, iframeSrc) {
+    return {
+      src: iframeSrc,
+      title: iframe.title || iframe.getAttribute('aria-label') || 'Embedded content'
+    };
+  }
+
+  function createIframePlaceholder(iframeSrc, iframeTitle) {
+    const linkDiv = document.createElement('div');
+    linkDiv.className = 'llmfeeder-iframe-link';
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode('[Embedded content: '));
+    const title = iframeTitle || 'Embedded content';
+    if (isHttpOrHttpsUrl(iframeSrc)) {
+      const a = document.createElement('a');
+      a.href = iframeSrc;
+      a.textContent = title;
+      p.appendChild(a);
+    } else {
+      p.appendChild(document.createTextNode(title));
+    }
+    p.appendChild(document.createTextNode(']'));
+    linkDiv.appendChild(p);
+    return linkDiv;
+  }
+
   function isSameOriginIframe(iframe) {
     try {
       if (!iframe.contentWindow) {
@@ -878,153 +870,78 @@
     }
   }
 
-  function extractSingleIframe(iframe, iframeSrc) {
-    return new Promise((resolve) => {
-      const messageId = `llmfeeder-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-      let timeoutId = null;
-      let messageHandler = null;
-
-      const cleanup = () => {
-        if (timeoutId) clearTimeout(timeoutId);
-        if (messageHandler) window.removeEventListener('message', messageHandler);
-      };
-
-      messageHandler = (event) => {
-        if (event.data &&
-            event.data.action === MESSAGE_ACTIONS.EXTRACT_RESPONSE &&
-            event.data.messageId === messageId) {
-          cleanup();
-          resolve({
-            success: true,
-            content: event.data.content,
-            src: iframeSrc
-          });
-        }
-      };
-
-      window.addEventListener('message', messageHandler);
-
-      timeoutId = setTimeout(() => {
-        cleanup();
-        resolve({ success: false, content: null, src: iframeSrc });
-      }, IFRAME_EXTRACTION_TIMEOUT);
-
-      try {
-        iframe.contentWindow.postMessage({
-          action: MESSAGE_ACTIONS.EXTRACT_CONTENT,
-          messageId: messageId
-        }, '*');
-      } catch (e) {
-        cleanup();
-        resolve({ success: false, content: null, src: iframeSrc });
-      }
-    });
+  function isHiddenEmptyIframe(iframe) {
+    return !iframe.offsetParent && !iframe.src && !iframe.srcdoc;
   }
 
-  async function extractIframesInBatches(iframes) {
-    const results = [];
-    for (let i = 0; i < iframes.length; i += MAX_IFRAME_BATCH_SIZE) {
-      const batch = iframes.slice(i, i + MAX_IFRAME_BATCH_SIZE);
-      const batchResults = await Promise.all(
-        batch.map(iframe => extractSingleIframe(iframe, iframe.src))
-      );
-      results.push(...batchResults);
+  function isRemoteIframeSrc(iframe) {
+    return !!(iframe.src && iframe.src !== 'about:blank' && iframe.src !== 'javascript:void(0)');
+  }
+
+  function tryExtractSameOriginIframe(iframe, iframeSrc, index) {
+    const iframeDoc = iframe.contentWindow.document;
+    const iframeBody = iframeDoc.body;
+    const clonedIframeContent = iframeBody.cloneNode(true);
+
+    const scripts = clonedIframeContent.querySelectorAll('script, style, noscript');
+    for (let j = scripts.length - 1; j >= 0; j--) {
+      scripts[j].parentNode.removeChild(scripts[j]);
     }
-    return results;
+
+    const iframeText = clonedIframeContent.textContent || '';
+    if (iframeText.trim().length <= MIN_CONTENT_LENGTH) {
+      return { skipped: true, contentLength: iframeText.length };
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'llmfeeder-iframe-content';
+    wrapper.setAttribute('data-iframe-src', iframeSrc);
+    wrapper.setAttribute('data-iframe-index', String(index));
+    while (clonedIframeContent.firstChild) {
+      wrapper.appendChild(clonedIframeContent.firstChild);
+    }
+    return { wrapper, contentLength: iframeText.length };
   }
 
-  /**
-   * Extract iframe content from the ORIGINAL document and append to content
-   * This is needed because Readability may remove iframes from the content
-   */
-  async function extractAndReplaceIframesFromOriginal(clonedContent, preserveIframeLinks) {
-    const originalIframes = Array.from(document.querySelectorAll('iframe'));
+  function collectIframeExtraction(iframes, logLabel) {
     const extractedContents = [];
     const crossOriginIframes = [];
-    const inaccessibleIframes = [];
 
-    DebugLog.log('Starting iframe extraction from original document', {
-      originalIframes: originalIframes.length
+    DebugLog.log(logLabel, {
+      originalIframes: iframes.length
     });
 
-    for (let i = 0; i < originalIframes.length; i++) {
-      const iframe = originalIframes[i];
+    for (let i = 0; i < iframes.length; i++) {
+      const iframe = iframes[i];
       const iframeSrc = iframe.src || iframe.srcdoc || 'about:blank';
 
-      // Skip hidden/empty iframes
-      if (!iframe.offsetParent && !iframe.src && !iframe.srcdoc) {
+      if (isHiddenEmptyIframe(iframe)) {
         continue;
       }
 
       if (isSameOriginIframe(iframe)) {
         try {
-          const iframeDoc = iframe.contentWindow.document;
-          const iframeBody = iframeDoc.body;
-          const clonedContent = iframeBody.cloneNode(true);
-
-          // Clean scripts, styles
-          const scripts = clonedContent.querySelectorAll('script, style, noscript');
-          for (let j = scripts.length - 1; j >= 0; j--) {
-            scripts[j].parentNode.removeChild(scripts[j]);
-          }
-
-          const iframeText = clonedContent.textContent || '';
-          if (iframeText.trim().length > MIN_CONTENT_LENGTH) {
-            const wrapper = document.createElement('div');
-            wrapper.className = 'llmfeeder-iframe-content';
-            wrapper.setAttribute('data-iframe-src', iframeSrc);
-            wrapper.setAttribute('data-iframe-index', i);
-            wrapper.innerHTML = clonedContent.innerHTML;
-            extractedContents.push(wrapper);
+          const result = tryExtractSameOriginIframe(iframe, iframeSrc, i);
+          if (result.wrapper) {
+            extractedContents.push(result.wrapper);
             DebugLog.log('Extracted same-origin iframe', {
               src: iframeSrc.substring(0, 50),
-              contentLength: iframeText.length
+              contentLength: result.contentLength
             });
           } else {
             DebugLog.log('Iframe skipped (not enough content)', {
               src: iframeSrc.substring(0, 50),
-              contentLength: iframeText.length
+              contentLength: result.contentLength
             });
           }
         } catch (e) {
           DebugLog.error('Same-origin iframe extraction failed', e);
           if (iframe.src) {
-            inaccessibleIframes.push({ iframe, index: i, src: iframeSrc });
+            crossOriginIframes.push(iframeFallbackInfo(iframe, iframeSrc));
           }
         }
-      } else if (iframe.src && iframe.src !== 'about:blank' && iframe.src !== 'javascript:void(0)') {
-        inaccessibleIframes.push({ iframe, index: i, src: iframeSrc });
-      }
-    }
-
-    // Try cross-origin via messaging
-    if (inaccessibleIframes.length > 0) {
-      DebugLog.log('Attempting cross-origin iframe extraction', {
-        count: inaccessibleIframes.length
-      });
-      const iframesToExtract = inaccessibleIframes.map(item => item.iframe);
-      const results = await extractIframesInBatches(iframesToExtract);
-
-      for (let j = 0; j < results.length; j++) {
-        const result = results[j];
-        const originalItem = inaccessibleIframes[j];
-
-        if (result.success && result.content) {
-          const wrapper = document.createElement('div');
-          wrapper.className = 'llmfeeder-iframe-content';
-          wrapper.setAttribute('data-iframe-src', result.src);
-          wrapper.setAttribute('data-iframe-index', originalItem.index);
-          wrapper.innerHTML = result.content;
-          extractedContents.push(wrapper);
-          DebugLog.log('Extracted cross-origin iframe via messaging', {
-            src: result.src.substring(0, 50)
-          });
-        } else {
-          crossOriginIframes.push({
-            src: result.src,
-            title: originalItem.iframe?.title || originalItem.iframe?.getAttribute('aria-label') || 'Embedded content'
-          });
-        }
+      } else if (isRemoteIframeSrc(iframe)) {
+        crossOriginIframes.push(iframeFallbackInfo(iframe, iframeSrc));
       }
     }
 
@@ -1033,9 +950,33 @@
       crossOrigin: crossOriginIframes.length
     });
 
-    // CRITICAL FIX: For mainContent scope, Readability has already removed iframes
-    // So we APPEND the extracted iframe content directly to the cloned content
-    // instead of trying to replace non-existent iframes
+    return { extractedContents, crossOriginIframes };
+  }
+
+  function crossOriginIframeWarnings(crossOriginIframes) {
+    if (crossOriginIframes.length === 0) {
+      return [];
+    }
+    return [{
+      type: 'crossOriginIframe',
+      count: crossOriginIframes.length,
+      details: crossOriginIframes.slice(0, 3)
+    }];
+  }
+
+  /**
+   * Extract iframe content from the ORIGINAL document and append to content
+   * This is needed because Readability may remove iframes from the content
+   */
+  async function extractAndReplaceIframesFromOriginal(clonedContent, preserveIframeLinks) {
+    const originalIframes = Array.from(document.querySelectorAll('iframe'));
+    const { extractedContents, crossOriginIframes } = collectIframeExtraction(
+      originalIframes,
+      'Starting iframe extraction from original document'
+    );
+
+    // For mainContent scope, Readability has already removed iframes, so
+    // append extracted iframe content directly to the cloned article.
     if (extractedContents.length > 0) {
       DebugLog.log('Appending extracted iframe content to cloned content', {
         count: extractedContents.length
@@ -1047,7 +988,11 @@
       extractedContents.forEach((wrapper, index) => {
         const section = document.createElement('div');
         section.className = 'llmfeeder-iframe-section';
-        section.innerHTML = `<hr>\n<h3>Embedded Content ${index + 1}</h3>\n` + wrapper.innerHTML;
+        section.appendChild(document.createElement('hr'));
+        const heading = document.createElement('h3');
+        heading.textContent = `Embedded Content ${index + 1}`;
+        section.appendChild(heading);
+        section.appendChild(wrapper);
         iframeSection.appendChild(section);
       });
 
@@ -1055,16 +1000,7 @@
       DebugLog.log('Appended iframe content to cloned content');
     }
 
-    const warnings = [];
-    if (crossOriginIframes.length > 0) {
-      warnings.push({
-        type: 'crossOriginIframe',
-        count: crossOriginIframes.length,
-        details: crossOriginIframes.slice(0, 3)
-      });
-    }
-
-    return warnings;
+    return crossOriginIframeWarnings(crossOriginIframes);
   }
 
   /**
@@ -1073,117 +1009,36 @@
    */
   async function extractAndReplaceIframesFromCloned(content, preserveIframeLinks) {
     const originalIframes = Array.from(document.querySelectorAll('iframe'));
-    const extractedContents = [];
-    const crossOriginIframes = [];
-    const inaccessibleIframes = [];
+    const { extractedContents, crossOriginIframes } = collectIframeExtraction(
+      originalIframes,
+      'Starting iframe extraction from cloned content'
+    );
 
-    DebugLog.log('Starting iframe extraction from cloned content', { 
-      originalIframes: originalIframes.length 
-    });
-
-    for (let i = 0; i < originalIframes.length; i++) {
-      const iframe = originalIframes[i];
-      const iframeSrc = iframe.src || iframe.srcdoc || 'about:blank';
-
-      if (!iframe.offsetParent && !iframe.src && !iframe.srcdoc) {
-        continue;
-      }
-
-      if (isSameOriginIframe(iframe)) {
-        try {
-          const iframeDoc = iframe.contentWindow.document;
-          const iframeBody = iframeDoc.body;
-          const clonedContent = iframeBody.cloneNode(true);
-
-          const scripts = clonedContent.querySelectorAll('script, style, noscript');
-          for (let j = scripts.length - 1; j >= 0; j--) {
-            scripts[j].parentNode.removeChild(scripts[j]);
-          }
-
-          const iframeText = clonedContent.textContent || '';
-          if (iframeText.trim().length > MIN_CONTENT_LENGTH) {
-            const wrapper = document.createElement('div');
-            wrapper.className = 'llmfeeder-iframe-content';
-            wrapper.setAttribute('data-iframe-src', iframeSrc);
-            wrapper.setAttribute('data-iframe-index', i);
-            wrapper.innerHTML = clonedContent.innerHTML;
-            extractedContents.push(wrapper);
-            DebugLog.log('Extracted same-origin iframe', { 
-              src: iframeSrc.substring(0, 50), 
-              contentLength: iframeText.length 
-            });
-          }
-        } catch (e) {
-          DebugLog.error('Same-origin iframe extraction failed', e);
-          if (iframe.src) {
-            inaccessibleIframes.push({ iframe, index: i, src: iframeSrc });
-          }
-        }
-      } else if (iframe.src && iframe.src !== 'about:blank' && iframe.src !== 'javascript:void(0)') {
-        inaccessibleIframes.push({ iframe, index: i, src: iframeSrc });
-      }
-    }
-
-    if (inaccessibleIframes.length > 0) {
-      const iframesToExtract = inaccessibleIframes.map(item => item.iframe);
-      const results = await extractIframesInBatches(iframesToExtract);
-
-      for (let j = 0; j < results.length; j++) {
-        const result = results[j];
-        const originalItem = inaccessibleIframes[j];
-
-        if (result.success && result.content) {
-          const wrapper = document.createElement('div');
-          wrapper.className = 'llmfeeder-iframe-content';
-          wrapper.setAttribute('data-iframe-src', result.src);
-          wrapper.setAttribute('data-iframe-index', originalItem.index);
-          wrapper.innerHTML = result.content;
-          extractedContents.push(wrapper);
-        } else {
-          crossOriginIframes.push({
-            src: result.src,
-            title: originalItem.iframe?.title || originalItem.iframe?.getAttribute('aria-label') || 'Embedded content'
-          });
-        }
-      }
-    }
-
-    // Replace iframes in cloned content
     const clonedIframes = Array.from(content.querySelectorAll('iframe'));
     for (let i = 0; i < clonedIframes.length; i++) {
       const iframe = clonedIframes[i];
       const iframeSrc = iframe.src || iframe.srcdoc || 'about:blank';
 
       const extractedContent = extractedContents.find(c =>
-        parseInt(c.getAttribute('data-iframe-index')) === i
+        parseInt(c.getAttribute('data-iframe-index'), 10) === i
       );
 
       if (extractedContent) {
         const replacementDiv = document.createElement('div');
         replacementDiv.className = 'llmfeeder-iframe-replacement';
-        replacementDiv.innerHTML = extractedContent.innerHTML;
+        while (extractedContent.firstChild) {
+          replacementDiv.appendChild(extractedContent.firstChild);
+        }
         iframe.parentNode.replaceChild(replacementDiv, iframe);
       } else if (preserveIframeLinks && iframeSrc && iframeSrc !== 'about:blank') {
-        const linkDiv = document.createElement('div');
-        linkDiv.className = 'llmfeeder-iframe-link';
         const iframeTitle = iframe.title || iframe.getAttribute('aria-label') || 'Embedded content';
-        linkDiv.innerHTML = `<p>[Embedded content: <a href="${iframeSrc}">${iframeTitle}</a>]</p>`;
-        iframe.parentNode.replaceChild(linkDiv, iframe);
+        iframe.parentNode.replaceChild(createIframePlaceholder(iframeSrc, iframeTitle), iframe);
       } else {
         iframe.parentNode.removeChild(iframe);
       }
     }
 
-    const warnings = [];
-    if (crossOriginIframes.length > 0) {
-      warnings.push({
-        type: 'crossOriginIframe',
-        count: crossOriginIframes.length,
-        details: crossOriginIframes.slice(0, 3)
-      });
-    }
-
-    return warnings;
+    return crossOriginIframeWarnings(crossOriginIframes);
   }
 
   // ==========================================================================

--- a/extension/content.js
+++ b/extension/content.js
@@ -614,10 +614,10 @@
     // For mainContent scope, we need to extract from original document since Readability may remove iframes
     let iframeWarnings = [];
     if (settings.contentScope === 'mainContent') {
-      iframeWarnings = await extractAndReplaceIframesFromOriginal(content, settings.preserveIframeLinks !== false);
+      iframeWarnings = extractAndReplaceIframesFromOriginal(content);
     }
     
-    const cleanWarnings = await cleanContent(content, settings);
+    const cleanWarnings = cleanContent(content, settings);
     iframeWarnings = iframeWarnings.concat(cleanWarnings);
 
     DebugLog.log('Iframe warnings', { count: iframeWarnings.length, types: iframeWarnings.map(w => w.type) });
@@ -976,7 +976,7 @@
    * Extract iframe content from the ORIGINAL document and append to content
    * This is needed because Readability may remove iframes from the content
    */
-  async function extractAndReplaceIframesFromOriginal(clonedContent, preserveIframeLinks) {
+  function extractAndReplaceIframesFromOriginal(clonedContent) {
     const originalIframes = Array.from(document.querySelectorAll('iframe'));
     const { extractedContents, crossOriginIframes } = collectIframeExtraction(
       originalIframes,
@@ -1015,7 +1015,7 @@
    * Extract and replace iframes for fullPage/selection scope
    * (For these scopes, iframes are still present in the cloned content)
    */
-  async function extractAndReplaceIframesFromCloned(content, preserveIframeLinks) {
+  function extractAndReplaceIframesFromCloned(content, preserveIframeLinks) {
     const originalIframes = Array.from(document.querySelectorAll('iframe'));
     const { extractedContents, crossOriginIframes } = collectIframeExtraction(
       originalIframes,
@@ -1053,12 +1053,12 @@
   // CONTENT CLEANING
   // ==========================================================================
 
-  async function cleanContent(content, settings) {
+  function cleanContent(content, settings) {
     // For fullPage and selection scopes, extract iframes from cloned content
     // For mainContent scope, this was already done before Readability
     let iframeWarnings = [];
     if (settings.contentScope !== 'mainContent') {
-      iframeWarnings = await extractAndReplaceIframesFromCloned(content, settings.preserveIframeLinks !== false);
+      iframeWarnings = extractAndReplaceIframesFromCloned(content, settings.preserveIframeLinks !== false);
     }
 
     // Remove elements that shouldn't be included

--- a/extension/content.js
+++ b/extension/content.js
@@ -824,8 +824,16 @@
   // link/warning instead of asking another window to echo its HTML.
 
   function isHttpOrHttpsUrl(src) {
+    if (!src || typeof src !== 'string') {
+      return false;
+    }
+    // Require an explicit http(s) URL so srcdoc HTML cannot be resolved as
+    // a relative path against the page.
+    if (!/^https?:\/\//i.test(src.trim())) {
+      return false;
+    }
     try {
-      const url = new URL(src, document.baseURI);
+      const url = new URL(src);
       return url.protocol === 'http:' || url.protocol === 'https:';
     } catch (e) {
       return false;

--- a/tests/content-script-isolation.test.js
+++ b/tests/content-script-isolation.test.js
@@ -12,6 +12,7 @@ describe('content script page isolation', () => {
   it('does not register a window message listener', () => {
     expect(source).not.toMatch(/addEventListener\(\s*['"]message['"]/);
     expect(source).not.toMatch(/llmfeeder_extract_content/);
+    expect(source).not.toMatch(/event\.source\.postMessage/);
   });
 
   it('does not echo document HTML in response to page messages', (done) => {

--- a/tests/content-script-isolation.test.js
+++ b/tests/content-script-isolation.test.js
@@ -1,0 +1,42 @@
+// Guards that the content script does not proxy page HTML over window messages.
+// The script is an IIFE, so we load it in jsdom and assert it stays silent.
+
+const fs = require('fs');
+const path = require('path');
+
+const CONTENT_SCRIPT = path.join(__dirname, '../extension/content.js');
+
+describe('content script page isolation', () => {
+  const source = fs.readFileSync(CONTENT_SCRIPT, 'utf8');
+
+  it('does not register a window message listener', () => {
+    expect(source).not.toMatch(/addEventListener\(\s*['"]message['"]/);
+    expect(source).not.toMatch(/llmfeeder_extract_content/);
+  });
+
+  it('does not echo document HTML in response to page messages', (done) => {
+    global.chrome.runtime = {
+      onMessage: { addListener: jest.fn() }
+    };
+    document.body.textContent = 'Secret account balance $42,784.49 and more padding text.';
+    require(CONTENT_SCRIPT);
+
+    const onMessage = (event) => {
+      if (event.data && event.data.action === 'llmfeeder_extract_content_response') {
+        window.removeEventListener('message', onMessage);
+        done(new Error('content script should not reply to unsolicited page messages'));
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    window.postMessage({
+      action: 'llmfeeder_extract_content',
+      messageId: 'isolation-check'
+    }, '*');
+
+    setTimeout(() => {
+      window.removeEventListener('message', onMessage);
+      done();
+    }, 150);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes Made

- Restrict iframe extraction to same-origin / srcdoc frames, reading them through the DOM the way the test bench already expects.
- Drop the unused `window.postMessage` path that asked other frames to echo HTML. Cross-origin iframes now consistently keep a link/warning instead.
- Build those placeholders with DOM APIs rather than interpolating `src` / `title` into HTML strings, and only turn an iframe `src` into a link when it is an explicit `http(s)` URL (so srcdoc HTML cannot be treated as a relative path).
- Drop the unused `preserveIframeLinks` argument on main-content iframe extraction and the leftover `async` on helpers that no longer await.
- Add a Jest guard so the content script stays silent when a page posts an unsolicited extract message.

## Test URLs

- http://localhost:8080/testbench.html — srcdoc iframe, nested same-origin iframe, Wikipedia cross-origin warning, sandboxed iframe placeholder, tables

## Screenshot

Full-page convert on the test bench (Chrome, unpacked build from this branch):

![LLMFeeder popup on the test bench](https://cursor.com/artifacts/c/art-4927c4d6-f8b6-4737-ada2-f297544ad53f)
![Settings with Full page content selected](https://cursor.com/artifacts/c/art-9016d2f8-aeee-4ae2-9f7e-22e11764a787)
![Convert and Copy succeeded with token count](https://cursor.com/artifacts/c/art-70776997-adae-4803-8ae0-6d631d04c8a5)
![Pasted markdown with nested iframe content found](https://cursor.com/artifacts/c/art-6edda2cb-218d-4047-ad07-6a97ab260e23)
![Pasted markdown with cross-origin iframe warning](https://cursor.com/artifacts/c/art-5bd9d1bc-4744-4f6d-a7bf-75edb8d56525)

<a href="https://cursor.com/agents/bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestbench_full_page_convert.mp4"><img src="https://cursor.com/artifacts/c/art-3b2e614e-5e4b-4572-89c4-1213eb604386" alt="testbench_full_page_convert.mp4" /></a>

Same-origin srcdoc and nested iframe content still extract. Cross-origin frames keep a link plus the existing warning. Sandboxed srcdoc is a text placeholder, not a bogus href. Chrome/Firefox/source packages build, manifests parse, and `npm test` is green (19 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

