### PR TITLE
chore: prepare v2.2.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,7 @@ The project uses two build methods:
 ./scripts/build.sh source
 
 # Build with custom version
-./scripts/build.sh --version 2.2.0 all
+./scripts/build.sh --version 2.2.1 all
 ```
 
 ### Output Files
@@ -403,12 +403,12 @@ Built packages are created in `dist/`:
 
 1. Edit `extension/manifest.json`:
    ```json
-   "version": "2.2.0"
+   "version": "2.2.1"
    ```
 
 2. Build with version:
    ```bash
-   ./scripts/build.sh --version 2.2.0 all
+   ./scripts/build.sh --version 2.2.1 all
    ```
 
 ---
@@ -441,8 +441,8 @@ Actions:
 
 ```bash
 # Tag and push
-git tag v2.2.0
-git push origin v2.2.0
+git tag v2.2.1
+git push origin v2.2.1
 
 # Then create release on GitHub
 # CI will automatically build and upload packages

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ A browser extension that converts web page content to clean Markdown format and 
 
 **Website:** [llmfeeder.fyi](https://llmfeeder.fyi/)
 
-## ✨ What's New in v2.2.0
+## ✨ What's New in v2.2.1
+
+- 🖼️ **More robust iframe extraction** - Same-origin and srcdoc frames are read through the DOM; cross-origin frames keep a link/warning instead of page-to-page HTML messaging
+- 🔗 **Safer iframe placeholders** - Embedded-content links are built with DOM APIs and only for explicit `http(s)` URLs
+
+### Previous Release (v2.2.0)
 
 - 📜 **Lazy-Loading Auto-Scroll** - Opt-in setting to scroll chat/AI pages (Gemini, ChatGPT, Claude, etc.) before extraction so long conversations aren't truncated (#91)
 - 📋 **Alternative Copy Mode** - Split copy button with a one-click override for Full Page vs Main Content without changing your default setting

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LLMFeeder - Web to Markdown for AI",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Convert any webpage to clean Markdown for ChatGPT, Claude & Gemini. Multi-tab copy, token counter. 100% private.",
   "author": "@jatinkrmalik",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llmfeeder",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Convert any webpage to clean Markdown for ChatGPT, Claude & Gemini. Multi-tab copy, token counter. 100% private.",
   "private": true,
   "scripts": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@
 # Usage: ./scripts/build.sh [chrome|firefox|source|all]
 
 # Default values
-VERSION="2.2.0"
+VERSION="2.2.1"
 TARGET="all"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/web/index.html
+++ b/web/index.html
@@ -124,7 +124,7 @@
             "description": "Strip nav, ads, and script noise from any page into clean Markdown for ChatGPT, Claude, and Gemini. Multi-tab copy, token counter, 100% private.",
             "url": "https://llmfeeder.fyi/",
             "downloadUrl": "https://chromewebstore.google.com/detail/llmfeeder/cjjfhhapabcpcokkfldbiiojiphbifdk",
-            "softwareVersion": "2.2.0",
+            "softwareVersion": "2.2.1",
             "license": "https://opensource.org/licenses/MIT",
             "isAccessibleForFree": true,
             "image": "https://llmfeeder.fyi/assets/og-image.png",
@@ -246,7 +246,7 @@
             Star on GitHub
           </a>
         </div>
-        <p class="cta-note">Free · MIT · v2.2.0 · No account, no telemetry</p>
+        <p class="cta-note">Free · MIT · v2.2.1 · No account, no telemetry</p>
 
         <a class="hero-hint" href="#convert">
           <span>Scroll to strip a page</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes Made

Patch release on top of #109 (now on `main`).

- Bump version **2.2.0 → 2.2.1** in `extension/manifest.json`, `package.json`, `scripts/build.sh`, `web/index.html`, README, and AGENTS.md
- Document the iframe extraction change in What's New (same-origin/srcdoc via the DOM; cross-origin frames keep a link/warning)

After merge, tag `v2.2.1` and create the GitHub release so CI can attach the zips.

## Test URLs

Desktop E2E on the built 2.2.1 packages (`dist/LLMFeeder-Chrome-v2.2.1.zip`, `dist/LLMFeeder-Firefox-v2.2.1.zip`). Convert & Copy succeeded on every site below.

**Chrome 2.2.1** (unpacked `aoimoanhlfamaciefppifeohnipbnide`)

| Site | Scope | Result | Tokens |
| --- | --- | --- | --- |
| https://example.com/ | default | Copied to clipboard! | 55 / 8K |
| https://en.wikipedia.org/wiki/Markdown | main | Copied (over 8K warning) | 11,776 / 8K |
| https://github.com/jatinkrmalik/LLMFeeder | main | Copied to clipboard! | 6,291 / 8K |
| http://127.0.0.1:8080/testbench.html | Full page | Copied to clipboard! | 1,246 / 8K |
| https://news.ycombinator.com/ | default | Copied to clipboard! | 4,143 / 8K |
| https://developer.mozilla.org/en-US/docs/Web/HTML | main (CDP) | success | 3,009 tokens |

**Firefox 2.2.1** (temporary add-on `llmfeeder@j47.in`)

| Site | Scope | Result | Tokens |
| --- | --- | --- | --- |
| https://example.com/ | default | Copied to clipboard! | 55 / 8K |
| https://en.wikipedia.org/wiki/Markdown | main | Copied (over 8K warning) | 11,776 / 8K |
| https://github.com/jatinkrmalik/LLMFeeder | main | Copied to clipboard! | 6,291 / 8K |
| https://developer.mozilla.org/en-US/docs/Web/HTML | main | Copied to clipboard! | 3,035 / 8K |
| http://127.0.0.1:8080/testbench.html | Full page | Copied to clipboard! | 1,246 / 8K |
| https://news.ycombinator.com/ | default | Copied to clipboard! | 4,151 / 8K |

`bash scripts/build.sh all` produces `dist/LLMFeeder-*-v2.2.1.zip`; Chrome/Firefox manifests parse and report `2.2.1`.

## Screenshot

Chrome 2.2.1 loaded unpacked:

![Chrome extensions page showing LLMFeeder 2.2.1](https://cursor.com/artifacts/c/art-c934e483-3242-4d18-9ff9-54977ebcba48)

Firefox 2.2.1 temporary add-on:

![Firefox Add-ons Manager showing LLMFeeder 2.2.1](https://cursor.com/artifacts/c/art-cf577b81-d020-4f39-942b-842181048d04)

Chrome Convert & Copy on example.com, Wikipedia, GitHub, and the test bench:

![Chrome example.com Copied 55/8K](https://cursor.com/artifacts/c/art-649eac8d-097d-46d3-b6b4-f76e995feb81)
![Chrome Wikipedia Copied 11776/8K](https://cursor.com/artifacts/c/art-336b7ca0-a079-4c65-b891-96409bff7477)
![Chrome GitHub Copied 6291/8K](https://cursor.com/artifacts/c/art-0038349a-3415-402b-b5e1-f2f2dd5b2249)
![Chrome testbench Copied 1246/8K](https://cursor.com/artifacts/c/art-36bba2a6-ac47-45bb-b3ee-284fbf72397e)

<a href="https://cursor.com/agents/bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchrome_e2e_four_sites_convert.mp4"><img src="https://cursor.com/artifacts/c/art-1ca954f8-51b0-49a1-aa34-dde84c0ac49b" alt="chrome_e2e_four_sites_convert.mp4" /></a>

Firefox Convert & Copy on the same set plus MDN and Hacker News:

![Firefox example.com Copied 55/8K](https://cursor.com/artifacts/c/art-4b64dae5-5eeb-492c-9a4e-f93a3ac10693)
![Firefox Wikipedia Copied 11776/8K](https://cursor.com/artifacts/c/art-f753dfae-a814-45ec-a4ef-6bd430668f9f)
![Firefox GitHub Copied 6291/8K](https://cursor.com/artifacts/c/art-711ef5d4-b926-41c9-b293-2b2f43205e2d)
![Firefox MDN Copied 3035/8K](https://cursor.com/artifacts/c/art-deed7a5a-b195-486f-9e21-d4329601f83c)
![Firefox testbench Copied 1246/8K](https://cursor.com/artifacts/c/art-6260ac83-7620-4607-9ce2-6aa554b2963e)
![Firefox Hacker News Copied 4151/8K](https://cursor.com/artifacts/c/art-abdaf28c-9e9d-4956-9c18-999021c7a25b)

<a href="https://cursor.com/agents/bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox_e2e_six_sites_convert_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5b52b473-aaea-4ce0-900a-a5d1fffdc104" alt="firefox_e2e_six_sites_convert_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4db7bf79-eedb-4e6d-b9c9-c0b671b29995&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

