### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,4 +442,4 @@ Thanks a lot for spending your time helping LLMFeeder grow.🍻
 
 ## Star Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jatinkrmalik/LLMFeeder&type=Date)](https://star-history.com/#jatinkrmalik/LLMFeeder&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jatinkrmalik/LLMFeeder&type=Date)](https://star-history.dera.page/#jatinkrmalik/LLMFeeder&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, which is a pity since it nicely shows how the project has grown. This PR points the chart to a working endpoint so it displays again.

No other changes.